### PR TITLE
MGMT-21040: Hide the infraenv concept better

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ The MCP server provides the following tools for interacting with the OpenShift A
   * `cluster_id`: Cluster ID (string, required)
   * `host_id`: Host ID (string, required)
 
-### Infrastructure Environment
+### ISO Download URL
 
-* **infraenv_info** - Get detailed information about the assisted installer infra env with the given ID. Contains data like ISO download URL and infra env metadata.
-  * `infraenv_id`: Infrastructure environment ID (string, required)
+* **cluster_iso_download_url** - Get ISO download URL(s) for a cluster. Returns ISO download URLs separated by newlines if multiple exist.
+  * `cluster_id`: Cluster ID (string, required)
 
 ### Host Management
 

--- a/service_client/assisted_service_api.py
+++ b/service_client/assisted_service_api.py
@@ -253,6 +253,43 @@ class InventoryClient:
             )
             raise
 
+    async def list_infra_envs(self, cluster_id: str) -> list[dict[str, Any]]:
+        """
+        List infrastructure environments for a specific cluster.
+
+        Args:
+            cluster_id: The unique identifier of the cluster.
+
+        Returns:
+            list[dict[str, Any]]: A list of infrastructure environment dictionaries for the cluster.
+        """
+        try:
+            log.info("Listing infrastructure environments for cluster %s", cluster_id)
+            result = await asyncio.to_thread(
+                self._installer_api().list_infra_envs, cluster_id=cluster_id
+            )
+            log.info(
+                "Successfully listed infrastructure environments for cluster %s",
+                cluster_id,
+            )
+            return cast(list[dict[str, Any]], result)
+        except ApiException as e:
+            log.error(
+                "API error while listing infrastructure environments for cluster %s: Status: %s, Reason: %s, Body: %s",
+                cluster_id,
+                e.status,
+                e.reason,
+                e.body,
+            )
+            raise
+        except Exception as e:
+            log.error(
+                "Unexpected error while listing infrastructure environments for cluster %s: %s",
+                cluster_id,
+                str(e),
+            )
+            raise
+
     async def create_cluster(
         self, name: str, version: str, single_node: bool, **cluster_params: Any
     ) -> models.Cluster:


### PR DESCRIPTION
The information in the infraenv is generally not of much use to the
user. This is why the entire concept is hidden from them in the SaaS UI.
In order to be able to support getting the download URL for clusters
created outside of the current session and to further hide the infraenv
concept this PR changes the infraenv_info tool into
cluster_iso_download_url which takes just a cluster ID as input.

While a cluster can have multiple infraenvs, this is currently not an
expected flow in the SaaS so we simply return all that we find without
additional context. In the future if this MCP server is required to
support multi-arch deployments (the most common use-case for multiple
infraenvs) then maybe more information will need to accompany the
multiple URLs.

![Screenshot From 2025-07-08 15-15-57](https://github.com/user-attachments/assets/fd3eb29b-14b1-49ec-a57c-cb49be85e437)


https://issues.redhat.com/browse/MGMT-21040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect the renaming and revised behavior of the ISO download URL tool, now associated with clusters instead of infra environments.

* **New Features**
  * Introduced a tool to retrieve ISO download URLs for a cluster, supporting multiple URLs if available.

* **Bug Fixes**
  * Improved error handling for cluster creation and ISO URL retrieval when expected data is missing.

* **Tests**
  * Added and updated tests to cover the new cluster ISO download URL functionality, including handling of multiple URLs and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->