### PR TITLE
MGMT-21039: Add a tool for getting URLs for cluster credentials

### DIFF
--- a/service_client/assisted_service_api.py
+++ b/service_client/assisted_service_api.py
@@ -621,3 +621,53 @@ class InventoryClient:
                 str(e),
             )
             raise
+
+    async def get_presigned_for_cluster_credentials(
+        self, cluster_id: str, file_name: str
+    ) -> models.PresignedUrl:
+        """
+        Get presigned URL for cluster credentials.
+
+        Args:
+            cluster_id: The unique identifier of the cluster.
+            file_name: The credential file to download. Must be one of:
+                      'kubeadmin-password', 'kubeconfig', 'kubeconfig-noingress'.
+
+        Returns:
+            models.PresignedUrl: The presigned URL model containing URL and optional expiration time.
+        """
+        try:
+            log.info(
+                "Getting presigned URL for cluster %s credentials file %s",
+                cluster_id,
+                file_name,
+            )
+            result = await asyncio.to_thread(
+                self._installer_api().v2_get_presigned_for_cluster_credentials,
+                cluster_id=cluster_id,
+                file_name=file_name,
+            )
+            log.info(
+                "Successfully retrieved presigned URL for cluster %s credentials file %s",
+                cluster_id,
+                file_name,
+            )
+            return cast(models.PresignedUrl, result)
+        except ApiException as e:
+            log.error(
+                "API error while getting presigned URL for cluster %s credentials file %s: Status: %s, Reason: %s, Body: %s",
+                cluster_id,
+                file_name,
+                e.status,
+                e.reason,
+                e.body,
+            )
+            raise
+        except Exception as e:
+            log.error(
+                "Unexpected error while getting presigned URL for cluster %s credentials file %s: %s",
+                cluster_id,
+                file_name,
+                str(e),
+            )
+            raise


### PR DESCRIPTION
Specifically this adds a tool function and a client function. The expiration time is only returned if it is non-zero, otherwise the tool description attempts to instruct the model to find the expiration in the URL (which it does fairly well). This is shown in the following screenshot

<img width="2545" height="1288" alt="Screenshot From 2025-07-10 11-07-02" src="https://github.com/user-attachments/assets/8e531420-763d-4f34-b756-07f2d4792e95" />

https://issues.redhat.com/browse/MGMT-21039


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to generate secure download links for various cluster credential files, including kubeconfig and admin passwords.
* **Tests**
  * Introduced new tests to verify correct handling of download link generation, including scenarios with and without expiration timestamps, and robust error handling for different response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->