### PR TITLE
updating image location

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1,10 +1,11 @@
 ---
 parameters:
 - name: IMAGE
-  value: "quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-service-mcp-saas-main/assisted-service-mcp-saas-main"
+  value: "quay.io/redhat-services-prod/assisted-installer-tenant/saas/assisted-service-mcp"
   description: "Container image for the assisted service Model Context Protocol (MCP) server"
 - name: IMAGE_TAG
-  value: "latest"
+  value: ""
+  required: true
   description: "Tag of the container image to deploy"
 - name: INVENTORY_URL
   value: "https://api.openshift.com/api/assisted-install/v2"


### PR DESCRIPTION
Changing the default value for IMAGE to the final location of the official build of the MCP server image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container image path to a new registry location.
  * Made the image tag parameter mandatory for deployments and removed its default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->