### PR TITLE
Add log level env

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -22,6 +22,9 @@ parameters:
 - name: CLIENT_DEBUG
   value: "false"
   description: "Whether to enable debug logging for the MCP client (True/False)"
+- name: LOGGING_LEVEL
+  value: "debug"
+  description: "Log level for the MCP server"
 - name: SERVICE_PORT
   value: "8000"
   description: "Port number on which the MCP service listens"
@@ -82,6 +85,8 @@ objects:
             value: ${PULL_SECRET_URL}
           - name: CLIENT_DEBUG
             value: ${CLIENT_DEBUG}
+          - name: LOGGING_LEVEL
+            value: ${LOGGING_LEVEL}
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
Set to debug to start as we get the service running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable log level setting (`LOGGING_LEVEL`) for the MCP server, allowing users to control server logging verbosity via deployment parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->