### PR TITLE
Add explicit expiration time to iso download tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,10 @@ The MCP server provides the following tools for interacting with the OpenShift A
 
 ### ISO Download URL
 
-* **cluster_iso_download_url** - Get ISO download URL(s) for a cluster. Returns ISO download URLs separated by newlines if multiple exist.
+* **cluster_iso_download_url** - Get ISO download URL(s) for a cluster. A formatted string containing ISO download URLs and optional expiration times. Each ISO's information is formatted as:
+  - URL: <download-url>
+  - Expires at: <expiration-timestamp> (if available)
+  Multiple ISOs are separated by blank lines.
   * `cluster_id`: Cluster ID (string, required)
 
 ### Host Management


### PR DESCRIPTION
Previously the model was showing inconsistent behavior regarding the expiration time. Sometimes it would extract it from the claims in the url, sometimes it would print it in a readable format, and sometimes it wouldn't print anything at all. This should make it more consistent.