### PR TITLE
Refresh the ISO URL when returning it

### DIFF
--- a/server.py
+++ b/server.py
@@ -228,19 +228,22 @@ async def cluster_iso_download_url(cluster_id: str) -> str:
         cluster_id,
     )
 
-    # Extract ISO URLs and expiration dates from each infra env
+    # Get presigned URLs for each infra env
     iso_info = []
     for infra_env in infra_envs:
-        iso_url = infra_env.get("download_url")
-        expires_at = infra_env.get("expires_at")
         infra_env_id = infra_env.get("id", "unknown")
 
-        if iso_url:
+        # Use the new get_infra_env_download_url method
+        presigned_url = await client.get_infra_env_download_url(infra_env_id)
+
+        if presigned_url.url:
             # Format the response as a readable string
-            response_parts = [f"URL: {iso_url}"]
+            response_parts = [f"URL: {presigned_url.url}"]
             # Only include expiration time if it's a meaningful date (not a zero/default value)
-            if expires_at and not str(expires_at).startswith("0001-01-01"):
-                response_parts.append(f"Expires at: {expires_at}")
+            if presigned_url.expires_at and not str(
+                presigned_url.expires_at
+            ).startswith("0001-01-01"):
+                response_parts.append(f"Expires at: {presigned_url.expires_at}")
 
             iso_info.append("\n".join(response_parts))
         else:

--- a/service_client/assisted_service_api.py
+++ b/service_client/assisted_service_api.py
@@ -671,3 +671,46 @@ class InventoryClient:
                 str(e),
             )
             raise
+
+    async def get_infra_env_download_url(
+        self, infra_env_id: str
+    ) -> models.PresignedUrl:
+        """
+        Get presigned download URL for an infrastructure environment.
+
+        Args:
+            infra_env_id: The unique identifier of the infrastructure environment.
+
+        Returns:
+            models.PresignedUrl: The presigned URL model containing URL and optional expiration time.
+        """
+        try:
+            log.info(
+                "Getting presigned download URL for infrastructure environment %s",
+                infra_env_id,
+            )
+            result = await asyncio.to_thread(
+                self._installer_api().get_infra_env_download_url,
+                infra_env_id=infra_env_id,
+            )
+            log.info(
+                "Successfully retrieved presigned download URL for infrastructure environment %s",
+                infra_env_id,
+            )
+            return cast(models.PresignedUrl, result)
+        except ApiException as e:
+            log.error(
+                "API error while getting presigned download URL for infrastructure environment %s: Status: %s, Reason: %s, Body: %s",
+                infra_env_id,
+                e.status,
+                e.reason,
+                e.body,
+            )
+            raise
+        except Exception as e:
+            log.error(
+                "Unexpected error while getting presigned download URL for infrastructure environment %s: %s",
+                infra_env_id,
+                str(e),
+            )
+            raise


### PR DESCRIPTION
The download URL in the infraenv will be valid for a few hours after the cluster is created, but once the URL expires the dedicated URL API is required to refresh it. This commit updates the `cluster_iso_download_url` tool to just use that API all the time instead of pulling the url and expiration out of the infraenv.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving infrastructure environment download URLs using a standardized method that returns presigned URLs with optional expiration details.

* **Refactor**
  * Improved and unified the formatting of presigned URLs for download links, ensuring consistent output across tools.

* **Tests**
  * Introduced new and updated test cases to cover the new download URL retrieval method and its error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->