### PR TITLE
Lazy load pull secret

### DIFF
--- a/service_client/assisted_service_api.py
+++ b/service_client/assisted_service_api.py
@@ -34,11 +34,18 @@ class InventoryClient:
     def __init__(self, access_token: str):
         """Initialize the InventoryClient with an access token."""
         self.access_token = access_token
-        self.pull_secret = self._get_pull_secret()
+        self._pull_secret: Optional[str] = None
         self.inventory_url = os.environ.get(
             "INVENTORY_URL", "https://api.openshift.com/api/assisted-install/v2"
         )
         self.client_debug = os.environ.get("CLIENT_DEBUG", "False").lower() == "true"
+
+    @property
+    def pull_secret(self) -> str:
+        """Lazy-load the pull secret when first accessed."""
+        if self._pull_secret is None:
+            self._pull_secret = self._get_pull_secret()
+        return self._pull_secret
 
     def _get_pull_secret(self) -> str:
         url = os.environ.get(


### PR DESCRIPTION
Previously we were querying OCM for the pull secret on every tool call but it's only needed when we create clusters or infraenvs. This commit changes the service client so that it only queries for the pull secret when it is required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how pull secret retrieval is handled, making it load only when needed rather than during initialization.

* **Tests**
  * Updated tests to explicitly trigger and verify the new lazy loading behavior of the pull secret.
  * Enhanced test reliability by consistently mocking pull secret retrieval during cluster and environment creation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->