### PR TITLE
Implement Prometheus metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,19 @@ The MCP server provides the following tools for interacting with the OpenShift A
 * **Create a cluster**: "Create a new cluster named 'my-cluster' with OpenShift 4.14 and base domain 'example.com'"
 * **Check cluster events**: "What events happened on cluster abc123?"
 * **Install a cluster**: "Start the installation for cluster abc123"
+
+## Prometheus Metrics
+
+The MCP server exposes Prometheus metrics to monitor tool usage and performance. The metrics are available at `http://localhost:8000/metrics` when the server is running.
+
+### Available Metrics
+
+* **assisted_service_mcp_tool_request_count** - Number of tool requests.
+* **assisted_service_mcp_tool_request_duration_sum** - Total time to run the tool, in seconds.
+* **assisted_service_mcp_tool_request_duration_count** - Total number of tool requests measured.
+* **assisted_service_mcp_tool_request_duration_bucket** - Number of tool requests organized in buckets.
+
+### Metric Labels
+
+All metrics include the following label:
+* **tool** - The name of the tool, for example `cluster_info`, `list_clusters`, etc.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "requests>=2.32.3",
     "retry>=0.9.2",
     "types-requests>=2.32.4.20250611",
+    "prometheus_client>=0.22.1",
 ]
 
 [dependency-groups]

--- a/service_client/__init__.py
+++ b/service_client/__init__.py
@@ -7,5 +7,6 @@ Red Hat's Assisted Service API to manage OpenShift cluster installations.
 
 from .assisted_service_api import InventoryClient
 from .logger import log
+from .metrics import metrics, track_tool_usage
 
-__all__ = ["InventoryClient", "log"]
+__all__ = ["InventoryClient", "log", "metrics", "track_tool_usage"]

--- a/service_client/metrics.py
+++ b/service_client/metrics.py
@@ -1,0 +1,56 @@
+"""
+Metrics for the MCP server.
+
+This module provides metrics for the MCP server.
+"""
+
+from typing import Callable, Any
+from functools import wraps
+
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    Counter,
+    Histogram,
+    generate_latest,
+)
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+
+
+# Define counter for request count
+REQUEST_COUNT = Counter(
+    "assisted_service_mcp_tool_request_count",
+    "Request count",
+    ["tool"],
+)
+
+# Define histogram for request latency
+REQUEST_LATENCY = Histogram(
+    "assisted_service_mcp_tool_request_duration",
+    "Request latency",
+    ["tool"],
+    buckets=(0.1, 1.0, 10.0, 30.0, float("inf")),
+)
+
+
+def track_tool_usage() -> Callable:
+    """Decorate MCP tools with this decorator to track tool usage metrics."""
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            tool_name = func.__name__
+            REQUEST_COUNT.labels(tool=tool_name).inc()
+            with REQUEST_LATENCY.labels(tool=tool_name).time():
+                response = await func(*args, **kwargs)
+            return response
+
+        return wrapper
+
+    return decorator
+
+
+# Metrics route
+async def metrics(_request: Request) -> PlainTextResponse:
+    """Metrics endpoint."""
+    return PlainTextResponse(generate_latest(), media_type=CONTENT_TYPE_LATEST)


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/MGMT-21159

Implemented Prometheus metrics endpoint and instrumentation for MCP tool usage:
- Added prometheus_client dependency
- Instrumented all MCP tools with request counts and duration histograms
- Added metrics server on the MCP server port (/metrics endpoint)
- Updated README with metrics documentation

The implementation is done using a decorator (inspired by https://github.com/redhat-ai-tools/jira-mcp-snowflake/pull/12).

An alternative I considered was using a Middleware (inspired by #5), but it is challenging to pass the MCP tool name in such a way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Prometheus metrics endpoint for monitoring tool usage and performance.
  * All tool actions are now tracked for request count and duration, with metrics accessible at `/metrics`.
* **Documentation**
  * Updated README with details on available Prometheus metrics and usage instructions.
* **Chores**
  * Added Prometheus client library as a project dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->