### PR TITLE
add name to Service in OpenShift template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -98,6 +98,6 @@ objects:
       app: assisted-service-mcp
     ports:
       - protocol: TCP
+        name: assisted-service-mcp
         port: ${{SERVICE_PORT}}
         targetPort: ${{SERVICE_PORT}}
-


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-21159

without the `name` property we can't monitor.

follow up on #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Service configuration to include a descriptive name for the port in the OpenShift template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->