### PR TITLE
MGMT-21086: support different protocols

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "assisted-service-client>=2.41.0.post3",
-    "fastmcp>=2.8.0",
+    "fastmcp>=2.10.6",
     "netaddr>=1.3.0",
     "requests>=2.32.3",
     "retry>=0.9.2",

--- a/template.yaml
+++ b/template.yaml
@@ -13,6 +13,9 @@ parameters:
 - name: SSO_URL
   value: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
   description: "URL for Red Hat Single Sign-On (SSO) OpenID Connect token endpoint"
+- name: TRANSPORT
+  value: "sse"
+  description: "MCP transport type. Valid values: 'http', 'streamable-http', 'sse'. Defaults to 'sse'."
 - name: PULL_SECRET_URL
   value: "https://api.openshift.com/api/accounts_mgmt/v1/access_token"
   description: "URL for accessing pull secrets via the accounts management API"
@@ -81,6 +84,8 @@ objects:
             value: ${INVENTORY_URL}
           - name: SSO_URL
             value: ${SSO_URL}
+          - name: TRANSPORT
+            value: ${TRANSPORT}
           - name: PULL_SECRET_URL
             value: ${PULL_SECRET_URL}
           - name: CLIENT_DEBUG

--- a/uv.lock
+++ b/uv.lock
@@ -47,6 +47,7 @@ dependencies = [
     { name = "assisted-service-client" },
     { name = "fastmcp" },
     { name = "netaddr" },
+    { name = "prometheus-client" },
     { name = "requests" },
     { name = "retry" },
     { name = "types-requests" },
@@ -71,8 +72,9 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "assisted-service-client", specifier = ">=2.41.0.post3" },
-    { name = "fastmcp", specifier = ">=2.8.0" },
+    { name = "fastmcp", specifier = ">=2.10.6" },
     { name = "netaddr", specifier = ">=1.3.0" },
+    { name = "prometheus-client", specifier = ">=0.22.1" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "retry", specifier = ">=0.9.2" },
     { name = "types-requests", specifier = ">=2.32.4.20250611" },
@@ -368,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "2.10.5"
+version = "2.10.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -382,9 +384,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/08/7e9c8dc9c2712ccc6393383ef6d7999b84f658ee37cabc42f853e72f86e1/fastmcp-2.10.5.tar.gz", hash = "sha256:f829e0b11c4d136db1d81e20e8acb19cf5108f64059482d1853f3c940326cf04", size = 1618410, upload-time = "2025-07-11T22:23:32.968Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/a0/eceb88277ef9e3a442e099377a9b9c29fb2fa724e234486e03a44ca1c677/fastmcp-2.10.6.tar.gz", hash = "sha256:5a7b3301f9f1b64610430caef743ac70175c4b812e1949f037e4db65b0a42c5a", size = 1640538, upload-time = "2025-07-19T20:02:12.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/74/453a1e6d7673b831a04ac0167d34a3c21cf2a17d55b4d242f262474fff1f/fastmcp-2.10.5-py3-none-any.whl", hash = "sha256:ab218f6a66b61f6f83c413d37aa18f5c30882c44c8925f39ecd02dd855826540", size = 201275, upload-time = "2025-07-11T22:23:31.314Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/05/4958cccbe862958d862b6a15f2d10d2f5ec3c411268dcb131a433e5e7a0d/fastmcp-2.10.6-py3-none-any.whl", hash = "sha256:9782416a8848cc0f4cfcc578e5c17834da620bef8ecf4d0daabf5dd1272411a2", size = 202613, upload-time = "2025-07-19T20:02:11.47Z" },
 ]
 
 [[package]]
@@ -632,6 +634,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/cf/40dde0a2be27cc1eb41e333d1a674a74ce8b8b0457269cc640fd42b07cf7/prometheus_client-0.22.1.tar.gz", hash = "sha256:190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28", size = 69746, upload-time = "2025-06-02T14:29:01.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/ae/ec06af4fe3ee72d16973474f122541746196aaa16cea6f66d18b963c6177/prometheus_client-0.22.1-py3-none-any.whl", hash = "sha256:cca895342e308174341b2cbf99a56bef291fbc0ef7b9e5412a0f26d653ba7094", size = 58694, upload-time = "2025-06-02T14:29:00.068Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add the possibility to support different protocols.
We can set the env var `TRANSPORT` to "sse", "http" or "streamable-http".
The default path for `sse` is `/sse` and for `streamable-http` is `/mcp`

We kept the default to SSE to maintain the current behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required version of the fastmcp dependency.
  * Improved internal naming consistency and updated import paths.
  * Enhanced app initialization to support configurable transport protocol via environment variable.
  * Refined token retrieval to improve header access.
  * Updated tests to use client-based tool invocation and unified header mocking.
  * Added a new deployment parameter to configure the transport protocol with default and allowed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->