### PR TITLE
Revert "MGMT-21086: support different protocols"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "assisted-service-client>=2.41.0.post3",
-    "fastmcp>=2.10.6",
+    "fastmcp>=2.8.0",
     "netaddr>=1.3.0",
     "requests>=2.32.3",
     "retry>=0.9.2",

--- a/server.py
+++ b/server.py
@@ -8,19 +8,18 @@ Red Hat's Assisted Service API to manage OpenShift cluster installations.
 import json
 import os
 import asyncio
-from typing import Literal, cast
 
 import requests
 import uvicorn
 from assisted_service_client import models
-from fastmcp import FastMCP
-from fastmcp.server.dependencies import get_http_headers
+from mcp.server.fastmcp import FastMCP
+
 
 from service_client import InventoryClient, metrics, track_tool_usage, initiate_metrics
 from service_client.logger import log
 
 
-mcp_server: FastMCP = FastMCP("AssistedService", host="0.0.0.0")
+mcp = FastMCP("AssistedService", host="0.0.0.0")
 
 
 def format_presigned_url(presigned_url: models.PresignedUrl) -> str:
@@ -66,11 +65,12 @@ def get_offline_token() -> str:
         log.debug("Found offline token in environment variables")
         return token
 
-    headers = get_http_headers()
-    token = headers.get("ocm-offline-token")
-    if token:
-        log.debug("Found offline token in request headers")
-        return token
+    request = mcp.get_context().request_context.request
+    if request is not None:
+        token = request.headers.get("OCM-Offline-Token")
+        if token:
+            log.debug("Found offline token in request headers")
+            return token
 
     log.error("No offline token found in environment or request headers")
     raise RuntimeError("No offline token found in environment or request headers")
@@ -92,13 +92,14 @@ def get_access_token() -> str:
     """
     log.debug("Attempting to retrieve access token")
     # First try to get the token from the authorization header:
-    headers = get_http_headers()
-    auth_header = headers.get("authorization")
-    if auth_header:
-        parts = auth_header.split()
-        if len(parts) == 2 and parts[0].lower() == "bearer":
-            log.debug("Found access token in authorization header")
-            return parts[1]
+    request = mcp.get_context().request_context.request
+    if request is not None:
+        header = request.headers.get("Authorization")
+        if header is not None:
+            parts = header.split()
+            if len(parts) == 2 and parts[0].lower() == "bearer":
+                log.debug("Found access token in authorization header")
+                return parts[1]
 
     # Now try to get the offline token, and generate a new access token from it:
     log.debug("Generating new access token from offline token")
@@ -117,7 +118,7 @@ def get_access_token() -> str:
     return response.json()["access_token"]
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def cluster_info(cluster_id: str) -> str:
     """
@@ -144,7 +145,7 @@ async def cluster_info(cluster_id: str) -> str:
     return result.to_str()
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def list_clusters() -> str:
     """
@@ -178,7 +179,7 @@ async def list_clusters() -> str:
     return json.dumps(resp)
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def cluster_events(cluster_id: str) -> str:
     """
@@ -202,7 +203,7 @@ async def cluster_events(cluster_id: str) -> str:
     return result
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def host_events(cluster_id: str, host_id: str) -> str:
     """
@@ -228,7 +229,7 @@ async def host_events(cluster_id: str, host_id: str) -> str:
     return result
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def cluster_iso_download_url(cluster_id: str) -> str:
     """
@@ -285,7 +286,7 @@ async def cluster_iso_download_url(cluster_id: str) -> str:
     return "\n\n".join(iso_info)
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def create_cluster(
     name: str, version: str, base_domain: str, single_node: bool
@@ -336,7 +337,7 @@ async def create_cluster(
     return cluster.id
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def set_cluster_vips(cluster_id: str, api_vip: str, ingress_vip: str) -> str:
     """
@@ -371,7 +372,7 @@ async def set_cluster_vips(cluster_id: str, api_vip: str, ingress_vip: str) -> s
     return result.to_str()
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def install_cluster(cluster_id: str) -> str:
     """
@@ -401,7 +402,7 @@ async def install_cluster(cluster_id: str) -> str:
     return result.to_str()
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def list_versions() -> str:
     """
@@ -422,7 +423,7 @@ async def list_versions() -> str:
     return json.dumps(result)
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def list_operator_bundles() -> str:
     """
@@ -443,7 +444,7 @@ async def list_operator_bundles() -> str:
     return json.dumps(result)
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def add_operator_bundle_to_cluster(cluster_id: str, bundle_name: str) -> str:
     """
@@ -471,7 +472,7 @@ async def add_operator_bundle_to_cluster(cluster_id: str, bundle_name: str) -> s
     return result.to_str()
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def cluster_credentials_download_url(cluster_id: str, file_name: str) -> str:
     """
@@ -515,7 +516,7 @@ async def cluster_credentials_download_url(cluster_id: str, file_name: str) -> s
     return format_presigned_url(result)
 
 
-@mcp_server.tool()
+@mcp.tool()
 @track_tool_usage()
 async def set_host_role(host_id: str, infraenv_id: str, role: str) -> str:
     """
@@ -545,20 +546,15 @@ async def set_host_role(host_id: str, infraenv_id: str, role: str) -> str:
 
 def list_tools() -> list[str]:
     """List all MCP tools."""
-    return list(asyncio.run(mcp_server.get_tools()))
 
+    async def mcp_list_tools() -> list[str]:
+        return [t.name for t in await mcp.list_tools()]
 
-def get_transport() -> Literal["http", "streamable-http", "sse"]:
-    """Get the transport type from the environment."""
-    t = os.getenv("TRANSPORT", "sse")
-    if t not in ["http", "streamable-http", "sse"]:
-        t = "sse"  # fallback to default
-    return cast(Literal["http", "streamable-http", "sse"], t)
+    return asyncio.run(mcp_list_tools())
 
 
 if __name__ == "__main__":
-    transport = get_transport()
-    app = mcp_server.http_app(transport=transport)
+    app = mcp.sse_app()
     initiate_metrics(list_tools())
     app.add_route("/metrics", metrics)
     uvicorn.run(app, host="0.0.0.0")

--- a/template.yaml
+++ b/template.yaml
@@ -13,9 +13,6 @@ parameters:
 - name: SSO_URL
   value: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
   description: "URL for Red Hat Single Sign-On (SSO) OpenID Connect token endpoint"
-- name: TRANSPORT
-  value: "sse"
-  description: "MCP transport type. Valid values: 'http', 'streamable-http', 'sse'. Defaults to 'sse'."
 - name: PULL_SECRET_URL
   value: "https://api.openshift.com/api/accounts_mgmt/v1/access_token"
   description: "URL for accessing pull secrets via the accounts management API"
@@ -84,8 +81,6 @@ objects:
             value: ${INVENTORY_URL}
           - name: SSO_URL
             value: ${SSO_URL}
-          - name: TRANSPORT
-            value: ${TRANSPORT}
           - name: PULL_SECRET_URL
             value: ${PULL_SECRET_URL}
           - name: CLIENT_DEBUG

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,14 +4,11 @@ Unit tests for the server module.
 
 import json
 import os
-from typing import Generator
+from typing import Generator, Tuple
 from unittest.mock import Mock, patch, call
 
 import pytest
 from requests.exceptions import RequestException
-
-from fastmcp import Client
-from mcp.types import TextContent
 
 from service_client import InventoryClient
 import server
@@ -28,10 +25,14 @@ class TestTokenFunctions:
     """Test cases for token handling functions."""
 
     @pytest.fixture
-    def mock_http_headers(self) -> Generator[Mock, None, None]:
-        """Mock HTTP headers for testing."""
-        with patch("server.get_http_headers") as mock_get_headers:
-            yield mock_get_headers
+    def mock_mcp_get_context(self) -> Generator[Tuple[Mock, Mock], None, None]:
+        """Mock MCP context for testing."""
+        mock_context = Mock()
+        mock_request = Mock()
+        mock_context.request_context.request = mock_request
+
+        with patch.object(server.mcp, "get_context", return_value=mock_context):
+            yield mock_context, mock_request
 
     def test_get_offline_token_from_environment(self) -> None:
         """Test retrieving offline token from environment variables."""
@@ -41,14 +42,15 @@ class TestTokenFunctions:
             assert result == test_token
 
     def test_get_offline_token_environment_takes_precedence(
-        self, mock_http_headers: Mock
+        self, mock_mcp_get_context: Tuple[Mock, Mock]
     ) -> None:
         """Test that environment token takes precedence over request header token."""
+        _mock_context, mock_request = mock_mcp_get_context
         env_token = "environment-token"
         header_token = "header-token"
 
         # Set up both environment and header tokens
-        mock_http_headers.return_value = {"ocm-offline-token": header_token}
+        mock_request.headers.get.return_value = header_token
 
         with patch.dict(os.environ, {"OFFLINE_TOKEN": env_token}):
             result = server.get_offline_token()
@@ -57,22 +59,28 @@ class TestTokenFunctions:
             assert result == env_token
 
             # Should not even check the request headers since env token was found
-            mock_http_headers.assert_not_called()
+            mock_request.headers.get.assert_not_called()
 
-    def test_get_offline_token_from_headers(self, mock_http_headers: Mock) -> None:
+    def test_get_offline_token_from_headers(
+        self, mock_mcp_get_context: Tuple[Mock, Mock]
+    ) -> None:
         """Test retrieving offline token from request headers."""
+        _mock_context, mock_request = mock_mcp_get_context
         test_token = "test-offline-token-header"
-        mock_http_headers.return_value = {"ocm-offline-token": test_token}
+        mock_request.headers.get.return_value = test_token
 
         # Ensure environment variable is not set
         with patch.dict(os.environ, {}, clear=True):
             result = server.get_offline_token()
             assert result == test_token
-            mock_http_headers.assert_called_once()
+            mock_request.headers.get.assert_called_once_with("OCM-Offline-Token")
 
-    def test_get_offline_token_not_found(self, mock_http_headers: Mock) -> None:
+    def test_get_offline_token_not_found(
+        self, mock_mcp_get_context: Tuple[Mock, Mock]
+    ) -> None:
         """Test error when offline token is not found."""
-        mock_http_headers.return_value = {}
+        _mock_context, mock_request = mock_mcp_get_context
+        mock_request.headers.get.return_value = None
 
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(RuntimeError) as exc_info:
@@ -81,28 +89,33 @@ class TestTokenFunctions:
 
     def test_get_offline_token_no_request(self) -> None:
         """Test offline token retrieval when no request is available."""
-        with patch("server.get_http_headers", return_value={}):
+        mock_context = Mock()
+        mock_context.request_context.request = None
+
+        with patch.object(server.mcp, "get_context", return_value=mock_context):
             with patch.dict(os.environ, {}, clear=True):
                 with pytest.raises(RuntimeError) as exc_info:
                     server.get_offline_token()
                 assert "No offline token found" in str(exc_info.value)
 
     def test_get_access_token_from_authorization_header(
-        self, mock_http_headers: Mock
+        self, mock_mcp_get_context: Tuple[Mock, Mock]
     ) -> None:
         """Test retrieving access token from Authorization header."""
+        _mock_context, mock_request = mock_mcp_get_context
         test_token = "test-access-token"
-        mock_http_headers.return_value = {"authorization": f"Bearer {test_token}"}
+        mock_request.headers.get.return_value = f"Bearer {test_token}"
 
         result = server.get_access_token()
         assert result == test_token
-        mock_http_headers.assert_called_once()
+        mock_request.headers.get.assert_called_once_with("Authorization")
 
     def test_get_access_token_invalid_authorization_header(
-        self, mock_http_headers: Mock
+        self, mock_mcp_get_context: Tuple[Mock, Mock]
     ) -> None:
         """Test access token retrieval with invalid Authorization header."""
-        mock_http_headers.return_value = {"authorization": "Invalid header format"}
+        _mock_context, mock_request = mock_mcp_get_context
+        mock_request.headers.get.return_value = "Invalid header format"
 
         with patch.object(server, "get_offline_token", return_value="offline-token"):
             with patch("requests.post") as mock_post:
@@ -114,10 +127,11 @@ class TestTokenFunctions:
                 assert result == "new-token"
 
     def test_get_access_token_no_authorization_header(
-        self, mock_http_headers: Mock
+        self, mock_mcp_get_context: Tuple[Mock, Mock]
     ) -> None:
         """Test access token retrieval without Authorization header."""
-        mock_http_headers.return_value = {}
+        _mock_context, mock_request = mock_mcp_get_context
+        mock_request.headers.get.return_value = None
 
         with patch.object(server, "get_offline_token", return_value="offline-token"):
             with patch("requests.post") as mock_post:
@@ -130,10 +144,11 @@ class TestTokenFunctions:
 
     @patch("requests.post")
     def test_get_access_token_generate_from_offline_token(
-        self, mock_post: Mock, mock_http_headers: Mock
+        self, mock_post: Mock, mock_mcp_get_context: Tuple[Mock, Mock]
     ) -> None:
         """Test generating access token from offline token."""
-        mock_http_headers.return_value = {}
+        _mock_context, mock_request = mock_mcp_get_context
+        mock_request.headers.get.return_value = None
 
         offline_token = "test-offline-token"
         access_token = "generated-access-token"
@@ -158,10 +173,11 @@ class TestTokenFunctions:
 
     @patch("requests.post")
     def test_get_access_token_custom_sso_url(
-        self, mock_post: Mock, mock_http_headers: Mock
+        self, mock_post: Mock, mock_mcp_get_context: Tuple[Mock, Mock]
     ) -> None:
         """Test access token generation with custom SSO URL."""
-        mock_http_headers.return_value = {}
+        _mock_context, mock_request = mock_mcp_get_context
+        mock_request.headers.get.return_value = None
 
         custom_sso_url = "https://custom-sso.example.com/token"
         offline_token = "test-offline-token"
@@ -188,10 +204,11 @@ class TestTokenFunctions:
 
     @patch("requests.post")
     def test_get_access_token_request_failure(
-        self, mock_post: Mock, mock_http_headers: Mock
+        self, mock_post: Mock, mock_mcp_get_context: Tuple[Mock, Mock]
     ) -> None:
         """Test access token generation request failure."""
-        mock_http_headers.return_value = {}
+        _mock_context, mock_request = mock_mcp_get_context
+        mock_request.headers.get.return_value = None
 
         mock_post.side_effect = RequestException("Network error")
 
@@ -201,7 +218,10 @@ class TestTokenFunctions:
 
     def test_get_access_token_no_request_context(self) -> None:
         """Test access token retrieval when no request context is available."""
-        with patch("server.get_http_headers", return_value={}):
+        mock_context = Mock()
+        mock_context.request_context.request = None
+
+        with patch.object(server.mcp, "get_context", return_value=mock_context):
             with patch.object(
                 server, "get_offline_token", return_value="offline-token"
             ):
@@ -238,19 +258,16 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         cluster_id = "test-cluster-id"
         cluster = create_test_cluster(cluster_id=cluster_id)
         mock_inventory_client.get_cluster.return_value = cluster
+
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "cluster_info", {"cluster_id": cluster_id}
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                assert resp.content[0].text == cluster.to_str()
-                mock_inventory_client.get_cluster.assert_called_once_with(
-                    cluster_id=cluster_id
-                )
+            result = await server.cluster_info(cluster_id)
+
+            assert result == cluster.to_str()
+            mock_inventory_client.get_cluster.assert_called_once_with(
+                cluster_id=cluster_id
+            )
 
     @pytest.mark.asyncio
     async def test_list_clusters_success(
@@ -278,13 +295,11 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool("list_clusters", {})
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                expected_result = json.dumps(mock_clusters)
-                assert resp.content[0].text == expected_result
-                mock_inventory_client.list_clusters.assert_called_once()
+            result = await server.list_clusters()
+
+            expected_result = json.dumps(mock_clusters)
+            assert result == expected_result
+            mock_inventory_client.list_clusters.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_cluster_events_success(
@@ -300,16 +315,12 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "cluster_events", {"cluster_id": cluster_id}
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                assert resp.content[0].text == mock_events
-                mock_inventory_client.get_events.assert_called_once_with(
-                    cluster_id=cluster_id
-                )
+            result = await server.cluster_events(cluster_id)
+
+            assert result == mock_events
+            mock_inventory_client.get_events.assert_called_once_with(
+                cluster_id=cluster_id
+            )
 
     @pytest.mark.asyncio
     async def test_host_events_success(
@@ -326,16 +337,12 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "host_events", {"cluster_id": cluster_id, "host_id": host_id}
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                assert resp.content[0].text == mock_events
-                mock_inventory_client.get_events.assert_called_once_with(
-                    cluster_id=cluster_id, host_id=host_id
-                )
+            result = await server.host_events(cluster_id, host_id)
+
+            assert result == mock_events
+            mock_inventory_client.get_events.assert_called_once_with(
+                cluster_id=cluster_id, host_id=host_id
+            )
 
     @pytest.mark.asyncio
     async def test_cluster_iso_download_url_success(
@@ -360,20 +367,14 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "cluster_iso_download_url", {"cluster_id": cluster_id}
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                expected_result = "URL: https://api.openshift.com/api/assisted-install/v2/infra-envs/test-id/downloads/image\nExpires at: 2023-12-31T23:59:59Z"
-                assert resp.content[0].text == expected_result
-                mock_inventory_client.list_infra_envs.assert_called_once_with(
-                    cluster_id
-                )
-                mock_inventory_client.get_infra_env_download_url.assert_called_once_with(
-                    "test-infraenv-id"
-                )
+            result = await server.cluster_iso_download_url(cluster_id)
+
+            expected_result = "URL: https://api.openshift.com/api/assisted-install/v2/infra-envs/test-id/downloads/image\nExpires at: 2023-12-31T23:59:59Z"
+            assert result == expected_result
+            mock_inventory_client.list_infra_envs.assert_called_once_with(cluster_id)
+            mock_inventory_client.get_infra_env_download_url.assert_called_once_with(
+                "test-infraenv-id"
+            )
 
     @pytest.mark.asyncio
     async def test_cluster_iso_download_url_multiple_infraenvs(
@@ -420,28 +421,22 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "cluster_iso_download_url", {"cluster_id": cluster_id}
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                expected_result = (
-                    "URL: https://api.openshift.com/api/assisted-install/v2/infra-envs/test-id-1/downloads/image\n"
-                    "Expires at: 2023-12-31T23:59:59Z\n\n"
-                    "URL: https://api.openshift.com/api/assisted-install/v2/infra-envs/test-id-2/downloads/image\n"
-                    "Expires at: 2024-01-15T12:00:00Z"
-                )
-                assert resp.content[0].text == expected_result
-                mock_inventory_client.list_infra_envs.assert_called_once_with(
-                    cluster_id
-                )
-                mock_inventory_client.get_infra_env_download_url.assert_has_calls(
-                    [
-                        call("test-infraenv-id-1"),
-                        call("test-infraenv-id-2"),
-                    ]
-                )
+            result = await server.cluster_iso_download_url(cluster_id)
+
+            expected_result = (
+                "URL: https://api.openshift.com/api/assisted-install/v2/infra-envs/test-id-1/downloads/image\n"
+                "Expires at: 2023-12-31T23:59:59Z\n\n"
+                "URL: https://api.openshift.com/api/assisted-install/v2/infra-envs/test-id-2/downloads/image\n"
+                "Expires at: 2024-01-15T12:00:00Z"
+            )
+            assert result == expected_result
+            mock_inventory_client.list_infra_envs.assert_called_once_with(cluster_id)
+            mock_inventory_client.get_infra_env_download_url.assert_has_calls(
+                [
+                    call("test-infraenv-id-1"),
+                    call("test-infraenv-id-2"),
+                ]
+            )
 
     @pytest.mark.asyncio
     async def test_cluster_iso_download_url_no_expiration(
@@ -466,20 +461,14 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "cluster_iso_download_url", {"cluster_id": cluster_id}
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                expected_result = "URL: https://api.openshift.com/api/assisted-install/v2/infra-envs/test-id/downloads/image"
-                assert resp.content[0].text == expected_result
-                mock_inventory_client.list_infra_envs.assert_called_once_with(
-                    cluster_id
-                )
-                mock_inventory_client.get_infra_env_download_url.assert_called_once_with(
-                    "test-infraenv-id"
-                )
+            result = await server.cluster_iso_download_url(cluster_id)
+
+            expected_result = "URL: https://api.openshift.com/api/assisted-install/v2/infra-envs/test-id/downloads/image"
+            assert result == expected_result
+            mock_inventory_client.list_infra_envs.assert_called_once_with(cluster_id)
+            mock_inventory_client.get_infra_env_download_url.assert_called_once_with(
+                "test-infraenv-id"
+            )
 
     @pytest.mark.asyncio
     async def test_cluster_iso_download_url_zero_expiration(
@@ -504,21 +493,15 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "cluster_iso_download_url", {"cluster_id": cluster_id}
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                # Should not include expiration time since it's a zero/default value
-                expected_result = "URL: https://api.openshift.com/api/assisted-install/v2/infra-envs/test-id/downloads/image"
-                assert resp.content[0].text == expected_result
-                mock_inventory_client.list_infra_envs.assert_called_once_with(
-                    cluster_id
-                )
-                mock_inventory_client.get_infra_env_download_url.assert_called_once_with(
-                    "test-infraenv-id"
-                )
+            result = await server.cluster_iso_download_url(cluster_id)
+
+            # Should not include expiration time since it's a zero/default value
+            expected_result = "URL: https://api.openshift.com/api/assisted-install/v2/infra-envs/test-id/downloads/image"
+            assert result == expected_result
+            mock_inventory_client.list_infra_envs.assert_called_once_with(cluster_id)
+            mock_inventory_client.get_infra_env_download_url.assert_called_once_with(
+                "test-infraenv-id"
+            )
 
     @pytest.mark.asyncio
     async def test_cluster_iso_download_url_no_infraenvs(
@@ -533,19 +516,10 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "cluster_iso_download_url", {"cluster_id": cluster_id}
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                assert (
-                    resp.content[0].text
-                    == "No ISO download URLs found for this cluster."
-                )
-                mock_inventory_client.list_infra_envs.assert_called_once_with(
-                    cluster_id
-                )
+            result = await server.cluster_iso_download_url(cluster_id)
+
+            assert result == "No ISO download URLs found for this cluster."
+            mock_inventory_client.list_infra_envs.assert_called_once_with(cluster_id)
 
     @pytest.mark.asyncio
     async def test_create_cluster_success(
@@ -575,30 +549,17 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "create_cluster",
-                    {
-                        "name": name,
-                        "version": version,
-                        "base_domain": base_domain,
-                        "single_node": single_node,
-                    },
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                assert resp.content[0].text == cluster.id
+            result = await server.create_cluster(
+                name, version, base_domain, single_node
+            )
+            assert result == cluster.id
 
-                mock_inventory_client.create_cluster.assert_called_once_with(
-                    name,
-                    version,
-                    single_node,
-                    base_dns_domain=base_domain,
-                    tags="chatbot",
-                )
-                mock_inventory_client.create_infra_env.assert_called_once_with(
-                    name, cluster_id="cluster-id", openshift_version=version
-                )
+            mock_inventory_client.create_cluster.assert_called_once_with(
+                name, version, single_node, base_dns_domain=base_domain, tags="chatbot"
+            )
+            mock_inventory_client.create_infra_env.assert_called_once_with(
+                name, cluster_id="cluster-id", openshift_version=version
+            )
 
     @pytest.mark.asyncio
     async def test_set_cluster_vips_success(
@@ -617,21 +578,12 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "set_cluster_vips",
-                    {
-                        "cluster_id": cluster_id,
-                        "api_vip": api_vip,
-                        "ingress_vip": ingress_vip,
-                    },
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                assert resp.content[0].text == cluster.to_str()
-                mock_inventory_client.update_cluster.assert_called_once_with(
-                    cluster_id, api_vip=api_vip, ingress_vip=ingress_vip
-                )
+            result = await server.set_cluster_vips(cluster_id, api_vip, ingress_vip)
+
+            assert result == cluster.to_str()
+            mock_inventory_client.update_cluster.assert_called_once_with(
+                cluster_id, api_vip=api_vip, ingress_vip=ingress_vip
+            )
 
     @pytest.mark.asyncio
     async def test_install_cluster_success(
@@ -647,16 +599,10 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "install_cluster", {"cluster_id": cluster_id}
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                assert resp.content[0].text == cluster.to_str()
-                mock_inventory_client.install_cluster.assert_called_once_with(
-                    cluster_id
-                )
+            result = await server.install_cluster(cluster_id)
+
+            assert result == cluster.to_str()
+            mock_inventory_client.install_cluster.assert_called_once_with(cluster_id)
 
     @pytest.mark.asyncio
     async def test_list_versions_success(
@@ -671,15 +617,11 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool("list_versions", {})
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                expected_result = json.dumps(mock_versions)
-                assert resp.content[0].text == expected_result
-                mock_inventory_client.get_openshift_versions.assert_called_once_with(
-                    True
-                )
+            result = await server.list_versions()
+
+            expected_result = json.dumps(mock_versions)
+            assert result == expected_result
+            mock_inventory_client.get_openshift_versions.assert_called_once_with(True)
 
     @pytest.mark.asyncio
     async def test_list_operator_bundles_success(
@@ -697,13 +639,11 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool("list_operator_bundles", {})
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                expected_result = json.dumps(mock_bundles)
-                assert resp.content[0].text == expected_result
-                mock_inventory_client.get_operator_bundles.assert_called_once()
+            result = await server.list_operator_bundles()
+
+            expected_result = json.dumps(mock_bundles)
+            assert result == expected_result
+            mock_inventory_client.get_operator_bundles.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_add_operator_bundle_to_cluster_success(
@@ -721,17 +661,14 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "add_operator_bundle_to_cluster",
-                    {"cluster_id": cluster_id, "bundle_name": bundle_name},
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                assert resp.content[0].text == cluster.to_str()
-                mock_inventory_client.add_operator_bundle_to_cluster.assert_called_once_with(
-                    cluster_id, bundle_name
-                )
+            result = await server.add_operator_bundle_to_cluster(
+                cluster_id, bundle_name
+            )
+
+            assert result == cluster.to_str()
+            mock_inventory_client.add_operator_bundle_to_cluster.assert_called_once_with(
+                cluster_id, bundle_name
+            )
 
     @pytest.mark.asyncio
     async def test_set_host_role_success(
@@ -750,17 +687,12 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "set_host_role",
-                    {"host_id": host_id, "infraenv_id": infraenv_id, "role": role},
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                assert resp.content[0].text == host.to_str()
-                mock_inventory_client.update_host.assert_called_once_with(
-                    host_id, infraenv_id, host_role=role
-                )
+            result = await server.set_host_role(host_id, infraenv_id, role)
+
+            assert result == host.to_str()
+            mock_inventory_client.update_host.assert_called_once_with(
+                host_id, infraenv_id, host_role=role
+            )
 
     @pytest.mark.asyncio
     async def test_cluster_credentials_download_url_success(
@@ -780,18 +712,15 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "cluster_credentials_download_url",
-                    {"cluster_id": cluster_id, "file_name": file_name},
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                expected_result = "URL: https://example.com/presigned-url\nExpires at: 2023-12-31T23:59:59Z"
-                assert resp.content[0].text == expected_result
-                mock_inventory_client.get_presigned_for_cluster_credentials.assert_called_once_with(
-                    cluster_id, file_name
-                )
+            result = await server.cluster_credentials_download_url(
+                cluster_id, file_name
+            )
+
+            expected_result = "URL: https://example.com/presigned-url\nExpires at: 2023-12-31T23:59:59Z"
+            assert result == expected_result
+            mock_inventory_client.get_presigned_for_cluster_credentials.assert_called_once_with(
+                cluster_id, file_name
+            )
 
     @pytest.mark.asyncio
     async def test_cluster_credentials_download_url_no_expiration(
@@ -811,18 +740,15 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "cluster_credentials_download_url",
-                    {"cluster_id": cluster_id, "file_name": file_name},
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                expected_result = "URL: https://example.com/presigned-url"
-                assert resp.content[0].text == expected_result
-                mock_inventory_client.get_presigned_for_cluster_credentials.assert_called_once_with(
-                    cluster_id, file_name
-                )
+            result = await server.cluster_credentials_download_url(
+                cluster_id, file_name
+            )
+
+            expected_result = "URL: https://example.com/presigned-url"
+            assert result == expected_result
+            mock_inventory_client.get_presigned_for_cluster_credentials.assert_called_once_with(
+                cluster_id, file_name
+            )
 
     @pytest.mark.asyncio
     async def test_cluster_credentials_download_url_zero_expiration(
@@ -844,16 +770,13 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):
-            async with Client(server.mcp_server) as client:
-                resp = await client.call_tool(
-                    "cluster_credentials_download_url",
-                    {"cluster_id": cluster_id, "file_name": file_name},
-                )
-                assert resp.content is not None and len(resp.content) > 0
-                assert isinstance(resp.content[0], TextContent)
-                # Should not include expiration time since it's a zero/default value
-                expected_result = "URL: https://example.com/presigned-url"
-                assert resp.content[0].text == expected_result
-                mock_inventory_client.get_presigned_for_cluster_credentials.assert_called_once_with(
-                    cluster_id, file_name
-                )
+            result = await server.cluster_credentials_download_url(
+                cluster_id, file_name
+            )
+
+            # Should not include expiration time since it's a zero/default value
+            expected_result = "URL: https://example.com/presigned-url"
+            assert result == expected_result
+            mock_inventory_client.get_presigned_for_cluster_credentials.assert_called_once_with(
+                cluster_id, file_name
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,6 @@ dependencies = [
     { name = "assisted-service-client" },
     { name = "fastmcp" },
     { name = "netaddr" },
-    { name = "prometheus-client" },
     { name = "requests" },
     { name = "retry" },
     { name = "types-requests" },
@@ -72,9 +71,8 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "assisted-service-client", specifier = ">=2.41.0.post3" },
-    { name = "fastmcp", specifier = ">=2.10.6" },
+    { name = "fastmcp", specifier = ">=2.8.0" },
     { name = "netaddr", specifier = ">=1.3.0" },
-    { name = "prometheus-client", specifier = ">=0.22.1" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "retry", specifier = ">=0.9.2" },
     { name = "types-requests", specifier = ">=2.32.4.20250611" },
@@ -370,7 +368,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "2.10.6"
+version = "2.10.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -384,9 +382,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/a0/eceb88277ef9e3a442e099377a9b9c29fb2fa724e234486e03a44ca1c677/fastmcp-2.10.6.tar.gz", hash = "sha256:5a7b3301f9f1b64610430caef743ac70175c4b812e1949f037e4db65b0a42c5a", size = 1640538, upload-time = "2025-07-19T20:02:12.543Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/08/7e9c8dc9c2712ccc6393383ef6d7999b84f658ee37cabc42f853e72f86e1/fastmcp-2.10.5.tar.gz", hash = "sha256:f829e0b11c4d136db1d81e20e8acb19cf5108f64059482d1853f3c940326cf04", size = 1618410, upload-time = "2025-07-11T22:23:32.968Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/05/4958cccbe862958d862b6a15f2d10d2f5ec3c411268dcb131a433e5e7a0d/fastmcp-2.10.6-py3-none-any.whl", hash = "sha256:9782416a8848cc0f4cfcc578e5c17834da620bef8ecf4d0daabf5dd1272411a2", size = 202613, upload-time = "2025-07-19T20:02:11.47Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/74/453a1e6d7673b831a04ac0167d34a3c21cf2a17d55b4d242f262474fff1f/fastmcp-2.10.5-py3-none-any.whl", hash = "sha256:ab218f6a66b61f6f83c413d37aa18f5c30882c44c8925f39ecd02dd855826540", size = 201275, upload-time = "2025-07-11T22:23:31.314Z" },
 ]
 
 [[package]]
@@ -634,15 +632,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.22.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/cf/40dde0a2be27cc1eb41e333d1a674a74ce8b8b0457269cc640fd42b07cf7/prometheus_client-0.22.1.tar.gz", hash = "sha256:190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28", size = 69746, upload-time = "2025-06-02T14:29:01.152Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/ae/ec06af4fe3ee72d16973474f122541746196aaa16cea6f66d18b963c6177/prometheus_client-0.22.1-py3-none-any.whl", hash = "sha256:cca895342e308174341b2cbf99a56bef291fbc0ef7b9e5412a0f26d653ba7094", size = 58694, upload-time = "2025-06-02T14:29:00.068Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Reverts openshift-assisted/assisted-service-mcp#38

In the integration environment we're seeing logs like this when tools are called:

```
2025-07-25 19:39:55,542 - mcp.server.sse - DEBUG    - 139666845583168:10 - Handling POST message - (/opt/app-root/src/.venv/lib/python3.13/site-packages/mcp/server/sse.py:202)->handle_post_message
2025-07-25 19:39:55,542 - mcp.server.sse - DEBUG    - 139666845583168:10 - Parsed session ID: c9705754-ea22-41bf-8ce2-cd20818007bc - (/opt/app-root/src/.venv/lib/python3.13/site-packages/mcp/server/sse.py:218)->handle_post_message
2025-07-25 19:39:55,542 - mcp.server.sse - DEBUG    - 139666845583168:10 - Received JSON: b'{"method":"tools/call","params":{"name":"list_versions","arguments":{"session_id":"1baad35c-3f97-4bb3-8d34-906a0eb0a76f"}},"jsonrpc":"2.0","id":1}' - (/opt/app-root/src/.venv/lib/python3.13/site-packages/mcp/server/sse.py:231)->handle_post_message
2025-07-25 19:39:55,542 - mcp.server.sse - DEBUG    - 139666845583168:10 - Validated client message: root=JSONRPCRequest(method='tools/call', params={'name': 'list_versions', 'arguments': {'session_id': '1baad35c-3f97-4bb3-8d34-906a0eb0a76f'}}, jsonrpc='2.0', id=1) - (/opt/app-root/src/.venv/lib/python3.13/site-packages/mcp/server/sse.py:235)->handle_post_message
2025-07-25 19:39:55,542 - mcp.server.sse - DEBUG    - 139666845583168:10 - Sending session message to writer: SessionMessage(message=JSONRPCMessage(root=JSONRPCRequest(method='tools/call', params={'name': 'list_versions', 'arguments': {'session_id': '1baad35c-3f97-4bb3-8d34-906a0eb0a76f'}}, jsonrpc='2.0', id=1)), metadata=ServerMessageMetadata(related_request_id=None, request_context=<starlette.requests.Request object at 0x7f06b546d0d0>)) - (/opt/app-root/src/.venv/lib/python3.13/site-packages/mcp/server/sse.py:246)->handle_post_message
INFO:     10.129.8.12:38048 - "POST /messages/?session_id=c9705754ea2241bf8ce2cd20818007bc HTTP/1.1" 202 Accepted
2025-07-25 19:39:55,543 - mcp.server.lowlevel.server - DEBUG    - 139666845583168:10 - Received message: <mcp.shared.session.RequestResponder object at 0x7f06b52e8550> - (/opt/app-root/src/.venv/lib/python3.13/site-packages/mcp/server/lowlevel/server.py:588)->run
2025-07-25 19:39:55,543 - mcp.server.lowlevel.server - INFO     - 139666845583168:10 - Processing request of type CallToolRequest - (/opt/app-root/src/.venv/lib/python3.13/site-packages/mcp/server/lowlevel/server.py:625)->_handle_request
2025-07-25 19:39:55,543 - mcp.server.lowlevel.server - DEBUG    - 139666845583168:10 - Dispatching request of type CallToolRequest - (/opt/app-root/src/.venv/lib/python3.13/site-packages/mcp/server/lowlevel/server.py:627)->_handle_request
[07/25/25 19:39:55] ERROR    Error calling tool              tool_manager.py:193
                             'list_versions'                                    
                             ╭─ Traceback (most recent cal─╮                    
                             │ /opt/app-root/src/.venv/lib │                    
                             │ /python3.13/site-packages/f │                    
                             │ astmcp/tools/tool_manager.p │                    
                             │ y:184 in call_tool          │                    
                             │                             │                    
                             │   181 │   │   │   │   raise │                    
                             │   182 │   │   │             │                    
                             │   183 │   │   │   try:      │                    
                             │ ❱ 184 │   │   │   │   retur │                    
                             │   185 │   │   │             │                    
                             │   186 │   │   │   # raise T │                    
                             │   187 │   │   │   except To │                    
                             │                             │                    
                             │ /opt/app-root/src/.venv/lib │                    
                             │ /python3.13/site-packages/f │                    
                             │ astmcp/tools/tool.py:275 in │                    
                             │ run                         │                    
                             │                             │                    
                             │   272 │   │   │   arguments │                    
                             │   273 │   │                 │                    
                             │   274 │   │   type_adapter  │                    
                             │ ❱ 275 │   │   result = type │                    
                             │   276 │   │                 │                    
                             │   277 │   │   if inspect.is │                    
                             │   278 │   │   │   result =  │                    
                             │                             │                    
                             │ /opt/app-root/src/.venv/lib │                    
                             │ /python3.13/site-packages/p │                    
                             │ ydantic/type_adapter.py:421 │                    
                             │  in validate_python         │                    
                             │                             │                    
                             │   418 │   │   │   │   code= │                    
                             │   419 │   │   │   )         │                    
                             │   420 │   │                 │                    
                             │ ❱ 421 │   │   return self.v │                    
                             │   422 │   │   │   object,   │                    
                             │   423 │   │   │   strict=st │                    
                             │   424 │   │   │   from_attr │                    
                             ╰─────────────────────────────╯                    
                             ValidationError: 1 validation                      
                             error for call[list_versions]                      
                             session_id                                         
                               Unexpected keyword argument                      
                             [type=unexpected_keyword_argume                    
                             nt,                                                
                             input_value='1baad35c-3f97-4bb3                    
                             -8d34-906a0eb0a76f',                               
                             input_type=str]                                    
                                 For further information                        
                             visit                                              
                             https://errors.pydantic.dev/2.1                    
                             1/v/unexpected_keyword_argument                    
2025-07-25 19:39:56,230 - mcp.server.lowlevel.server - DEBUG    - 139666845583168:10 - Response sent - (/opt/app-root/src/.venv/lib/python3.13/site-packages/mcp/server/lowlevel/server.py:668)->_handle_request
2025-07-25 19:39:56,231 - mcp.server.sse - DEBUG    - 139666845583168:10 - Sending message via SSE: SessionMessage(message=JSONRPCMessage(root=JSONRPCResponse(jsonrpc='2.0', id=1, result={'content': [{'type': 'text', 'text': "Error calling tool 'list_versions': 1 validation error for call[list_versions]\nsession_id\n  Unexpected keyword argument [type=unexpected_keyword_argument, input_value='1baad35c-3f97-4bb3-8d34-906a0eb0a76f', input_type=str]\n    For further information visit https://errors.pydantic.dev/2.11/v/unexpected_keyword_argument"}], 'isError': True})), metadata=None) - (/opt/app-root/src/.venv/lib/python3.13/site-packages/mcp/server/sse.py:172)->sse_writer
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified and simplified server implementation, including changes to server instance usage, token header access, tool listing, and server startup process.
  * Removed transport parameter configuration from deployment template.
  * Updated and streamlined tests to use direct server function calls and improved mocking of request context.

* **Chores**
  * Lowered the minimum required version of a core dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->