### PR TITLE
MGMT-21215: Allow setting or updating cluster ssh public key

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The MCP server provides the following tools for interacting with the OpenShift A
   * `version`: OpenShift version (string, required)
   * `base_domain`: Base domain for the cluster (string, required)
   * `single_node`: Whether to create a single node cluster (boolean, required)
+  * `ssh_public_key`: SSH public key for accessing cluster nodes (string, optional)
 
 * **install_cluster** - Trigger installation for the assisted installer cluster with the given ID
   * `cluster_id`: Cluster ID (string, required)
@@ -121,6 +122,12 @@ The MCP server provides the following tools for interacting with the OpenShift A
   * `infraenv_id`: Infrastructure environment ID (string, required)
   * `role`: Host role (string, required)
 
+### SSH Key Management
+
+* **set_cluster_ssh_key** - Set or update the SSH public key for a cluster. This allows SSH access to cluster nodes during and after installation.
+  * `cluster_id`: Cluster ID (string, required)
+  * `ssh_public_key`: SSH public key in OpenSSH format (string, required)
+
 ### OpenShift Versions and Operators
 
 * **list_versions** - Lists the available OpenShift versions for installation with the assisted installer
@@ -138,6 +145,8 @@ The MCP server provides the following tools for interacting with the OpenShift A
 * **Create a cluster**: "Create a new cluster named 'my-cluster' with OpenShift 4.14 and base domain 'example.com'"
 * **Check cluster events**: "What events happened on cluster abc123?"
 * **Install a cluster**: "Start the installation for cluster abc123"
+* **Get cluster credentials**: "Get the kubeconfig download link for cluster abc123"
+* **Update SSH key**: "Set the SSH key for cluster abc123 so I can access the nodes"
 
 ## Prometheus Metrics
 

--- a/doc/example_prompts.md
+++ b/doc/example_prompts.md
@@ -61,6 +61,12 @@ Assign a specific role to a discovered host.
 - "Set host master-node-1 in my-cluster to be a master node"
 - "Assign worker role to host worker-node-2 in my-cluster"
 
+### `set_cluster_ssh_key`
+Set or update the SSH public key for a cluster to allow SSH access to nodes.
+
+**Example Prompts:**
+- "Set the SSH key for my-cluster to ssh-rsa AAAAB3NzaC1yc2E..."
+
 ## Downloads and Resources
 
 ### `cluster_iso_download_url`

--- a/service_client/assisted_service_api.py
+++ b/service_client/assisted_service_api.py
@@ -283,6 +283,30 @@ class InventoryClient:
         return cast(models.InfraEnv, result)
 
     @sanitize_exceptions
+    async def update_infra_env(
+        self, infra_env_id: str, **update_params: Any
+    ) -> models.InfraEnv:
+        """
+        Update infrastructure environment configuration.
+
+        Args:
+            infra_env_id: The unique identifier of the infrastructure environment to update.
+            **update_params: Infrastructure environment update parameters.
+
+        Returns:
+            models.InfraEnv: The updated infrastructure environment object.
+        """
+        params = models.InfraEnvUpdateParams(**update_params)
+        log.info("Updating infrastructure environment %s", infra_env_id)
+        result = await asyncio.to_thread(
+            self._installer_api().update_infra_env,
+            infra_env_id=infra_env_id,
+            infra_env_update_params=params,
+        )
+        log.info("Successfully updated infrastructure environment %s", infra_env_id)
+        return cast(models.InfraEnv, result)
+
+    @sanitize_exceptions
     async def update_cluster(
         self,
         cluster_id: str,


### PR DESCRIPTION
This PR adds an optional parameter to the cluster create tool for the ssh public key which adds it to both the created cluster and infraenv. Additionally a new tool is added to update the ssh public key for existing clusters. The update tool also updates all associated infraenvs.

Resolves https://issues.redhat.com/browse/MGMT-21215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to specify an SSH public key when creating a cluster, enabling SSH access to cluster nodes.
  * Introduced a new tool to set or update the SSH public key for an existing cluster, allowing SSH access during and after installation.

* **Documentation**
  * Updated user guides and examples to include SSH key management for clusters and usage instructions for the new tool.

* **Tests**
  * Added tests to verify SSH key handling during cluster creation and updates, including error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->