### PR TITLE
MGMT-21236: Allow setting cpu arch when creating a cluster

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -557,10 +557,18 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
             assert result == cluster.id
 
             mock_inventory_client.create_cluster.assert_called_once_with(
-                name, version, single_node, base_dns_domain=base_domain, tags="chatbot"
+                name,
+                version,
+                single_node,
+                base_dns_domain=base_domain,
+                tags="chatbot",
+                cpu_architecture="x86_64",
             )
             mock_inventory_client.create_infra_env.assert_called_once_with(
-                name, cluster_id="cluster-id", openshift_version=version
+                name,
+                cluster_id="cluster-id",
+                openshift_version=version,
+                cpu_architecture="x86_64",
             )
 
     @pytest.mark.asyncio
@@ -603,6 +611,7 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
                 single_node,
                 base_dns_domain=base_domain,
                 tags="chatbot",
+                cpu_architecture="x86_64",
                 ssh_public_key=ssh_public_key,
             )
             mock_inventory_client.create_infra_env.assert_called_once_with(
@@ -610,6 +619,56 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
                 cluster_id="cluster-id",
                 openshift_version=version,
                 ssh_authorized_key=ssh_public_key,
+                cpu_architecture="x86_64",
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_cluster_with_cpu_architecture_success(
+        self,
+        mock_inventory_client: Mock,
+        mock_get_access_token: None,  # pylint: disable=unused-argument
+    ) -> None:
+        """Test successful create_cluster function with specific CPU architecture."""
+        name = "test-cluster"
+        version = "4.18.2"
+        base_domain = "example.com"
+        single_node = False
+        cpu_architecture = "aarch64"
+
+        cluster = create_test_cluster(
+            cluster_id="cluster-id",
+            name=name,
+            openshift_version=version,
+        )
+        infraenv = create_test_infra_env(
+            infra_env_id="infraenv-id",
+            name=name,
+        )
+
+        mock_inventory_client.create_cluster.return_value = cluster
+        mock_inventory_client.create_infra_env.return_value = infraenv
+
+        with patch.object(
+            server, "InventoryClient", return_value=mock_inventory_client
+        ):
+            result = await server.create_cluster(
+                name, version, base_domain, single_node, None, cpu_architecture
+            )
+            assert result == cluster.id
+
+            mock_inventory_client.create_cluster.assert_called_once_with(
+                name,
+                version,
+                single_node,
+                base_dns_domain=base_domain,
+                tags="chatbot",
+                cpu_architecture=cpu_architecture,
+            )
+            mock_inventory_client.create_infra_env.assert_called_once_with(
+                name,
+                cluster_id="cluster-id",
+                openshift_version=version,
+                cpu_architecture=cpu_architecture,
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/MGMT-21236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying CPU architecture when creating a cluster. Supported architectures include x86_64, aarch64, arm64, ppc64le, and s390x.

* **Tests**
  * Updated and added tests to verify cluster creation with different CPU architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->