### PR TITLE
MGMT-21086: Set TRANSPORT in template to streamable-http

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -41,7 +41,7 @@ parameters:
   value: "50m"
   description: "Initial CPU request for the container (in millicores)"
 - name: TRANSPORT
-  value: "sse"
+  value: "streamable-http"
   description: "MCP Server transport type, can be sse or streamable-http"
 
 apiVersion: template.openshift.io/v1


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-21086

Merge with https://github.com/rh-ecosystem-edge/assisted-chat/pull/92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default transport type setting to "streamable-http" for improved connectivity options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->