### PR TITLE
MGMT-21356: Add operator names to tool description

### DIFF
--- a/server.py
+++ b/server.py
@@ -482,9 +482,8 @@ async def list_operator_bundles() -> str:
     """
     List available operator bundles for cluster installation.
 
-    Retrieves operator bundles that can be optionally installed during cluster
-    deployment. These include Red Hat and certified partner operators for
-    various functionalities like storage, networking, and monitoring.
+    Retrieves details about operator bundles that can be optionally installed
+    during cluster deployment.
 
     Returns:
         str: A JSON string containing available operator bundles with metadata
@@ -509,8 +508,8 @@ async def add_operator_bundle_to_cluster(cluster_id: str, bundle_name: str) -> s
 
     Args:
         cluster_id (str): The unique identifier of the cluster to configure.
-        bundle_name (str): The name of the operator bundle to add. Use
-            list_operator_bundles() to see available bundle names.
+        bundle_name (str): The name of the operator bundle to add.
+            The available operator bundle names are "virtualization" and "openshift-ai"
 
     Returns:
         str: A formatted string containing the updated cluster configuration


### PR DESCRIPTION
Before this asking the bot to add an operator by name would cause it to attempt to call `add_operator_bundle_to_cluster` with an invalid name. Listing the available operators would solve the issue, but since we only allow two operator bundles it's easier to just add the valid names to the description.

Listing the bundles will still give more information about them like which individual operators are included in the bundle if the user needs that info.

https://issues.redhat.com/browse/MGMT-21356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified descriptions around retrieving details for operator bundles available during cluster deployment, removing vendor-specific emphasis.
  * Improved guidance on adding an operator bundle by explicitly listing valid bundle names: “virtualization” and “openshift-ai”.
  * Enhanced docstrings for public API clarity; no functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->