### PR TITLE
add ServiceAccount to openshift template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -49,6 +49,14 @@ kind: Template
 metadata:
   name: assisted-service-mcp
 objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: assisted-service-mcp
+    labels:
+      app: assisted-service-mcp
+  imagePullSecrets:
+  - name: quay.io
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/template.yaml
+++ b/template.yaml
@@ -73,6 +73,7 @@ objects:
         labels:
           app: assisted-service-mcp
       spec:
+        serviceAccountName: assisted-service-mcp
         containers:
         - name: assisted-service-mcp
           image: ${IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-21020

adding a ServiceAccount to avoid using default and also using a pull secret for auth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a dedicated service account and bound the deployment to it to support authenticated image pulls from the container registry.
  * Configured image pull secrets to ensure reliable access to registry-hosted images.
  * Improves deployment hygiene and scopes cluster permissions more tightly.
  * No functional changes to application behavior or service configuration; existing services and deployments continue to operate unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->