### PR TITLE
MGMT-21476: Increase resources

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -29,16 +29,16 @@ parameters:
   value: "8000"
   description: "Port number on which the MCP service listens"
 - name: MEMORY_LIMIT
-  value: "128Mi"
+  value: "512Mi"
   description: "Maximum memory allocation for the container"
 - name: CPU_LIMIT
-  value: "100m"
+  value: "1000m"
   description: "Maximum CPU allocation for the container (in millicores)"
 - name: MEMORY_REQUEST
-  value: "64Mi"
+  value: "128Mi"
   description: "Initial memory request for the container"
 - name: CPU_REQUEST
-  value: "50m"
+  value: "100m"
   description: "Initial CPU request for the container (in millicores)"
 - name: TRANSPORT
   value: "streamable-http"


### PR DESCRIPTION
The containers were killed for memory usage during the scale test and were also CPU bound during local performance testing.

This python application can't utilize more that a single core so bump the limit to 1

https://issues.redhat.com/browse/MGMT-21476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased CPU and memory allocations for the service to enhance runtime capacity.
  * Users may experience smoother performance and fewer interruptions during peak usage.
  * No changes to user-facing functionality or interfaces.
  * Networking/transport settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->