### PR TITLE
copy metrics to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN uv sync
 
 COPY server.py .
 COPY service_client ./service_client/
+COPY metrics ./metrics/
 
 RUN chown -R 1001:0 ${APP_HOME}
 


### PR DESCRIPTION
this PR copies the `metrics` directory to the container for it to be found.

this fixes an error introduced in #67:
```
Traceback (most recent call last):
  File "/opt/app-root/src/server.py", line 19, in <module>
    from service_client import InventoryClient
  File "/opt/app-root/src/service_client/__init__.py", line 8, in <module>
    from .assisted_service_api import InventoryClient
  File "/opt/app-root/src/service_client/assisted_service_api.py", line 20, in <module>
    from metrics.metrics import API_CALL_LATENCY
ModuleNotFoundError: No module named 'metrics'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Container image now includes the metrics directory, ensuring metrics files are present at runtime.
  * Build process unchanged otherwise; ownership and startup steps remain the same.
  * Building the image now requires a metrics directory in the build context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->