### PR TITLE
switch from fastmcp to mcp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN uv sync
 
 COPY server.py .
 COPY service_client ./service_client/
+COPY metrics ./metrics/
 
 RUN chown -R 1001:0 ${APP_HOME}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "assisted-service-client>=2.41.0.post3",
-    "fastmcp>=2.8.0",
+    "mcp>=1.13.0",
     "netaddr>=1.3.0",
     "requests>=2.32.3",
     "retry>=0.9.2",


### PR DESCRIPTION
switch from https://pypi.org/project/fastmcp to https://pypi.org/project/mcp, which is the official python sdk under https://github.com/modelcontextprotocol/python-sdk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Included metrics assets in the application container, improving observability by making metrics available at runtime during deployments.
  - Updated a dependency to the current package name with a lower minimum supported version, improving compatibility and easing environment setup.
  - General build configuration adjustments to support the above changes without altering user-facing functionality or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->