### PR TITLE
MGMT-21600: Remove cluster name validation from the mcp server

### DIFF
--- a/server.py
+++ b/server.py
@@ -318,12 +318,7 @@ async def create_cluster(  # pylint: disable=too-many-arguments,too-many-positio
     (multi-node) or single-node deployment.
 
     Args:
-        name (str): The name for the new cluster. The cluster name must meet the
-            following requirements, refuse to accept cluster names that fail any of these:
-              - Be between 1 and 54 characters
-              - Use only lowercase alphanumeric characters or the hyphen (-)
-              - Start and end with a lowercase letter or number
-            Strictly adhere to these rules, check every cluster name carefully.
+        name (str): The name for the new cluster.
         version (str): The OpenShift version to install (e.g., "4.18.2", "4.17.1").
             Use list_versions() to see available versions.
         base_domain (str): The base DNS domain for the cluster (e.g., "example.com").


### PR DESCRIPTION
With this change assised-chat doesn't complain:
```
Enter your query (or type 'exit' to quit): name:itzik versio:4.21 base domain: test.you 
Our conversation ID: e1f7cabc-306e-4c52-a994-914438a3a7bb
conversation_id: e1f7cabc-306e-4c52-a994-914438a3a7bb
response: 'Thanks! Just to confirm, you want to create a cluster with the following
  details:


  *   Name: itzik

  *   OpenShift version: 4.21

  *   Base domain: test.you


  Is that correct?
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the description of the “name” parameter when creating a cluster, replacing verbose validation details with a concise explanation.
  * Streamlined wording to improve readability without changing functionality or behavior.
  * No impact on commands, APIs, or error handling; usage remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->