### PR TITLE
MGMT-21349: tool description update for vips

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ The MCP server provides the following tools for interacting with the OpenShift A
   * `cluster_id`: Cluster ID (string, required)
   * `api_vip`: API virtual IP address (string, required)
   * `ingress_vip`: Ingress virtual IP address (string, required)
+  
+  Notes:
+  * Use only for multi-node clusters with user-managed networking disabled. Single-node clusters and clusters with user-managed networking do not require VIPs.
+  * Ensure hosts are discovered first (after booting with the Discovery ISO) so that matching subnets are known; attempting to set VIPs earlier can result in errors such as `No suitable matching CIDR found for VIP`.
 
 ### Events and Monitoring
 

--- a/doc/example_prompts.md
+++ b/doc/example_prompts.md
@@ -44,6 +44,10 @@ Create a new OpenShift cluster.
 ### `set_cluster_vips`
 Configure virtual IP addresses for cluster API and ingress.
 
+Notes:
+- Only applicable for multi-node clusters with user-managed networking disabled.
+- Run this after hosts have been discovered (post-ISO boot). Attempting it too early may fail due to unknown subnets.
+
 **Example Prompts:**
 - "Set the API VIP to 192.168.1.100 and ingress VIP to 192.168.1.101 for my-cluster"
 - "Configure cluster my-cluster with API VIP 10.0.0.10 and ingress VIP 10.0.0.11"

--- a/server.py
+++ b/server.py
@@ -396,6 +396,13 @@ async def set_cluster_vips(cluster_id: str, api_vip: str, ingress_vip: str) -> s
     for the specified cluster. These VIPs must be available IP addresses within the
     cluster's network subnet.
 
+    Preconditions:
+      - Hosts must be discovered for the cluster so that subnets are known. Attempting to
+        set VIPs before any hosts are discovered typically fails with errors such as
+        "No suitable matching CIDR found for VIP".
+      - Only applicable to multi-node clusters with user-managed networking disabled. Single-node
+        clusters (SNO) and clusters with user-managed networking do not require setting VIPs.
+
     Args:
         cluster_id (str): The unique identifier of the cluster to configure.
         api_vip (str): The IP address for the cluster API endpoint. This is where


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified VIP requirements: only needed for multi-node clusters when user-managed networking is disabled; not required for single-node or user-managed networking.
  * Added instruction to set VIPs only after hosts are discovered (post-Discovery ISO boot) to avoid “No suitable matching CIDR found for VIP” errors.
  * Added “Preconditions”/Notes to command/help text and example docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->