### PR TITLE
adding the tag latest to the konflux builds, so getting the latest image would be easier

### DIFF
--- a/.tekton/assisted-service-mcp-saas-main-push.yaml
+++ b/.tekton/assisted-service-mcp-saas-main-push.yaml
@@ -106,6 +106,10 @@ spec:
       description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
+    - default:
+      - latest
+      name: additional-tags
+      type: array
     results:
     - description: ""
       name: IMAGE_URL
@@ -530,6 +534,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value: 
+        - $(params.additional-tags[*])
       runAfter:
       - build-image-index
       taskRef:

--- a/scripts/deploy_from_template.sh
+++ b/scripts/deploy_from_template.sh
@@ -8,30 +8,13 @@ IMAGE=""
 TAG=""
 
 if [[ -n $ASSISTED_MCP_IMG ]]; then
+     echo "The variable ASSISTED_MCP_IMG was proided with the value ${ASSISTED_MCP_IMG}, using it to create the IMAGE and TAG variables for the template"
     IMAGE=$(echo $ASSISTED_MCP_IMG | cut -d ":" -f1)
     TAG=$(echo $ASSISTED_MCP_IMG | cut -d ":" -f2)
 else
-    NEWEST_TAG=""
-    NEWEST_DATE=0
-
-    TAGS=$(curl -Lf https://quay.io/v2/redhat-services-prod/assisted-installer-tenant/saas/assisted-service-mcp/tags/list | jq -r '.tags[]'|grep -v sha256)
-    for TAG in $TAGS; do
-        if [[ "${#TAG}" == "7" ]]; then
-            MANIFEST=$(curl -Lf "https://quay.io/v2/redhat-services-prod/assisted-installer-tenant/saas/assisted-service-mcp/manifests/$TAG" | jq -r '.history[0].v1Compatibility')
-            CREATED_DATE=$(echo "$MANIFEST" | jq -r '.created' | xargs -I {} date -d {} +%s)
-            
-            if [[ $CREATED_DATE -gt $NEWEST_DATE ]]; then
-                NEWEST_DATE=$CREATED_DATE
-                NEWEST_TAG=$TAG
-            fi
-        fi
-    done
-    IMAGE="quay.io/redhat-services-prod/assisted-installer-tenant/saas/assisted-service-mcp"
-    if [[ -z "$NEWEST_TAG" ]]; then
-        echo "Unable to resolve the newest 7-char tag from quay.io"
-        exit 1
-    fi
-    TAG=$NEWEST_TAG
+    IMAGE=quay.io/redhat-user-workloads/assisted-installer-tenant/assisted-service-mcp-saas-main/assisted-service-mcp-saas-main
+    echo "The variable ASSISTED_MCP_IMG was not provieded, downloading the latest image from ${IMAGE}"
+    TAG="latest"
 fi
 
 oc process -p IMAGE=$IMAGE -p IMAGE_TAG=$TAG -f template.yaml --local | oc apply -n $NAMESPACE -f -


### PR DESCRIPTION
adding the tag latest to the konflux builds, so getting the latest image would be easier
the latest tag is only available in redhat-user-workloads so the latest tag has to be fetched from there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Pipeline now supports supplying extra image tags, enabling tagging images with multiple labels during runs.

- Chores
  - Deployment defaults to a fixed image path and uses the “latest” tag when no image is provided, replacing dynamic tag discovery.
  - Added clearer console messages indicating the chosen image and tag during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->