### PR TITLE
MGMT-21692 Update set_host_role to use cluster_id instead of infraenv_id

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -819,6 +819,12 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         host = create_test_host(host_id=host_id, role=role)
         mock_inventory_client.update_host.return_value = host
 
+        # Mock InfraEnvs list
+        mock_infra_envs = [
+            {"id": infraenv_id, "name": "infraenv"},
+        ]
+        mock_inventory_client.list_infra_envs.return_value = mock_infra_envs
+
         with patch.object(
             server, "InventoryClient", return_value=mock_inventory_client
         ):


### PR DESCRIPTION
- Update set_host_role function to accept cluster_id instead of infraenv_id
- Extract shared helper _get_cluster_infra_env_id() used by both set_host_role and set_cluster_ssh_key
- Handle edge cases where InfraEnvs may not have valid IDs

This change aligns with SaaS expectations where clusters typically have a single InfraEnv, making the InfraEnv concept an internal implementation detail rather than a user-facing parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized resolution of the infra environment for cluster-scoped host role and SSH key operations for more consistent behavior.
  * Host role updates now operate at the cluster level and add support for a new "worker" role.
  * Streamlined SSH key update flow with clearer partial-update messages when lookups or updates fail; improved cluster-scoped logging.

* **Tests**
  * Updated tests to align with the new cluster-scoped behavior and SSH key update flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->