### PR TITLE
changeing the pull secret for the mcp server so the evaluation tests could succeed

### DIFF
--- a/scripts/deploy_from_template.sh
+++ b/scripts/deploy_from_template.sh
@@ -17,7 +17,11 @@ else
     TAG="latest"
 fi
 
-oc process -p IMAGE=$IMAGE -p IMAGE_TAG=$TAG -p INVENTORY_URL="https://api.stage.openshift.com/api/assisted-install/v2" -f template.yaml --local | oc apply -n $NAMESPACE -f -
+oc process -p IMAGE=$IMAGE \
+           -p IMAGE_TAG=$TAG \
+           -p INVENTORY_URL="https://api.stage.openshift.com/api/assisted-install/v2" \
+           -p PULL_SECRET_URL="https://api.stage.openshift.com/api/accounts_mgmt/v1/access_token" \
+           -f template.yaml --local | oc apply -n $NAMESPACE -f -
 
 sleep 5
 if ! oc rollout status  -n $NAMESPACE deployment/assisted-service-mcp --timeout=300s; then


### PR DESCRIPTION
changeing the pull secret for the mcp server so the evaluation tests could succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment command reformatted for clearer multi-line readability and now accepts a PULL_SECRET_URL parameter.
  * Existing IMAGE, IMAGE_TAG and INVENTORY_URL parameters are preserved.
  * Default pull secret URL points to the staging token endpoint.
  * No user-facing behavior changes; deployment is functionally the same aside from configurable pull secret source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->