### PR TITLE
Add tools for static network configuration

### DIFF
--- a/service_client/static_net.py
+++ b/service_client/static_net.py
@@ -1,0 +1,127 @@
+"""Static networking related functionality."""
+
+import json
+from typing import TypedDict, cast
+
+
+class MacInterfaceMap(TypedDict):
+    """Maps a NIC to a MAC Address."""
+
+    logical_nic_name: str
+    mac_address: str
+
+
+class HostStaticNetworkConfig(TypedDict):
+    """Matches the structure in the Assisted Installer API."""
+
+    mac_interface_map: list[MacInterfaceMap]
+    network_yaml: str
+
+
+def add_or_update_static_host_config(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    existing_static_network_config: str | None,
+    dns_server: str,
+    mac_address: str,
+    ip_address: str,
+    subnet_prefix_len: int,
+    gateway_address: str,
+) -> list[HostStaticNetworkConfig]:
+    """Generate and append or replace the config for a given mac address."""
+    config: list[HostStaticNetworkConfig] = []
+    if existing_static_network_config:
+        config = [
+            cast(HostStaticNetworkConfig, d)
+            for d in json.loads(existing_static_network_config)
+        ]
+
+    i = find_host_config_index_for_mac(mac_address, config)
+    if i is None:
+        host_conf = HostStaticNetworkConfig(
+            {
+                "mac_interface_map": [
+                    {
+                        "logical_nic_name": "eth0",
+                        "mac_address": mac_address,
+                    }
+                ],
+                "network_yaml": "",
+            }
+        )
+        config.append(host_conf)
+        i = len(config) - 1
+
+    config[i]["network_yaml"] = generate_basic_nmstate_yaml(
+        dns_server,
+        ip_address,
+        subnet_prefix_len,
+        gateway_address,
+    )
+
+    return config
+
+
+def find_host_config_index_for_mac(
+    mac_address: str, host_configs: list[HostStaticNetworkConfig]
+) -> int | None:
+    """Find the index of the host config for the given mac_address.
+
+    Do a simple linear search since the list should be fairly small. The returned config refers to
+    the original object in the list.
+    """
+    for i, c in enumerate(host_configs):
+        for m in c["mac_interface_map"]:
+            if m["mac_address"].lower() == mac_address.lower():
+                return i
+    return None
+
+
+def generate_basic_nmstate_yaml(
+    dns_server: str,
+    ip_address: str,
+    subnet_prefix_len: int,
+    gateway_address: str,
+) -> str:
+    """Generate a basic NMState config with the given parameters."""
+    return f"""
+interfaces:
+  - name: eth0
+    type: ethernet
+    state: up
+    ipv4:
+      address:
+        - ip: {ip_address}
+          prefix-length: {subnet_prefix_len}
+      enabled: true
+      dhcp: false
+dns-resolver:
+  config:
+    server:
+      - "{dns_server}"
+routes:
+  config:
+    - destination: 0.0.0.0/0
+      next-hop-address: {gateway_address}
+      next-hop-interface: eth0
+      table-id: 254
+"""
+
+
+def remove_static_host_config(
+    existing_static_network_config: str | None,
+    mac_address: str,
+) -> list[HostStaticNetworkConfig]:
+    """Remove the static config for the given MAC."""
+    config: list[HostStaticNetworkConfig] = []
+    if existing_static_network_config:
+        config = [
+            cast(HostStaticNetworkConfig, d)
+            for d in json.loads(existing_static_network_config)
+        ]
+
+    i = find_host_config_index_for_mac(mac_address, config)
+    if i is not None:
+        del config[i]
+    else:
+        raise ValueError(f"host config for mac address {mac_address} does not exist")
+
+    return config

--- a/tests/test_static_net.py
+++ b/tests/test_static_net.py
@@ -1,0 +1,306 @@
+# type: ignore
+"""
+Unit tests for the static_net module.
+"""
+
+import json
+import pytest
+
+from service_client.static_net import (
+    add_or_update_static_host_config,
+    find_host_config_index_for_mac,
+    generate_basic_nmstate_yaml,
+    remove_static_host_config,
+)
+
+
+class TestFindHostConfigIndexForMac:
+    """Test cases for find_host_config_index_for_mac function."""
+
+    def test_find_existing_mac_address(self):
+        """Test finding an existing MAC address."""
+        configs = [
+            {
+                "mac_interface_map": [
+                    {
+                        "logical_nic_name": "eth0",
+                        "mac_address": "00:11:22:33:44:55",
+                    }
+                ],
+                "network_yaml": "yaml1",
+            },
+            {
+                "mac_interface_map": [
+                    {
+                        "logical_nic_name": "eth0",
+                        "mac_address": "aa:bb:cc:dd:ee:ff",
+                    }
+                ],
+                "network_yaml": "yaml2",
+            },
+        ]
+
+        index = find_host_config_index_for_mac("aa:bb:cc:dd:ee:ff", configs)
+        assert index == 1
+
+    def test_find_nonexistent_mac_address(self):
+        """Test searching for a MAC address that doesn't exist."""
+        configs = [
+            {
+                "mac_interface_map": [
+                    {
+                        "logical_nic_name": "eth0",
+                        "mac_address": "00:11:22:33:44:55",
+                    }
+                ],
+                "network_yaml": "yaml1",
+            }
+        ]
+
+        index = find_host_config_index_for_mac("ff:ff:ff:ff:ff:ff", configs)
+        assert index is None
+
+    def test_find_mac_in_multiple_interfaces(self):
+        """Test finding MAC address when host has multiple interfaces."""
+        configs = [
+            {
+                "mac_interface_map": [
+                    {
+                        "logical_nic_name": "eth0",
+                        "mac_address": "00:11:22:33:44:55",
+                    },
+                    {
+                        "logical_nic_name": "eth1",
+                        "mac_address": "aa:bb:cc:dd:ee:ff",
+                    },
+                ],
+                "network_yaml": "yaml1",
+            }
+        ]
+
+        index = find_host_config_index_for_mac("aa:bb:cc:dd:ee:ff", configs)
+        assert index == 0
+
+    def test_find_mac_in_empty_list(self):
+        """Test searching in an empty configuration list."""
+        index = find_host_config_index_for_mac("00:11:22:33:44:55", [])
+        assert index is None
+
+
+class TestGenerateBasicNmstateYaml:
+    """Test cases for generate_basic_nmstate_yaml function."""
+
+    def test_generate_yaml_with_valid_parameters(self):
+        """Test generating YAML with valid network parameters."""
+        yaml_content = generate_basic_nmstate_yaml(
+            dns_server="8.8.8.8",
+            ip_address="192.168.1.100",
+            subnet_prefix_len=24,
+            gateway_address="192.168.1.1",
+        )
+
+        assert "8.8.8.8" in yaml_content
+        assert "192.168.1.100" in yaml_content
+        assert "prefix-length: 24" in yaml_content
+        assert "192.168.1.1" in yaml_content
+
+
+class TestAddOrUpdateStaticHostConfig:
+    """Test cases for add_or_update_static_host_config function."""
+
+    def test_add_new_host_config_to_empty_list(self):
+        """Test adding a new host configuration to an empty list."""
+        result = add_or_update_static_host_config(
+            existing_static_network_config=None,
+            dns_server="8.8.8.8",
+            mac_address="00:11:22:33:44:55",
+            ip_address="192.168.1.100",
+            subnet_prefix_len=24,
+            gateway_address="192.168.1.1",
+        )
+
+        assert len(result) == 1
+        assert result[0]["mac_interface_map"][0]["mac_address"] == "00:11:22:33:44:55"
+        assert result[0]["mac_interface_map"][0]["logical_nic_name"] == "eth0"
+        assert "192.168.1.100" in result[0]["network_yaml"]
+
+    def test_add_new_host_config_to_existing_list(self):
+        """Test adding a new host configuration to an existing list."""
+        existing_config = json.dumps(
+            [
+                {
+                    "mac_interface_map": [
+                        {
+                            "logical_nic_name": "eth0",
+                            "mac_address": "aa:bb:cc:dd:ee:ff",
+                        }
+                    ],
+                    "network_yaml": "existing yaml",
+                }
+            ]
+        )
+
+        result = add_or_update_static_host_config(
+            existing_static_network_config=existing_config,
+            dns_server="8.8.8.8",
+            mac_address="00:11:22:33:44:55",
+            ip_address="192.168.1.100",
+            subnet_prefix_len=24,
+            gateway_address="192.168.1.1",
+        )
+
+        assert len(result) == 2
+        # Verify the original config is preserved
+        assert result[0]["mac_interface_map"][0]["mac_address"] == "aa:bb:cc:dd:ee:ff"
+        assert result[0]["network_yaml"] == "existing yaml"
+        # Verify the new config is added
+        assert result[1]["mac_interface_map"][0]["mac_address"] == "00:11:22:33:44:55"
+        assert "192.168.1.100" in result[1]["network_yaml"]
+
+    def test_update_existing_host_config(self):
+        """Test updating an existing host configuration."""
+        existing_config = json.dumps(
+            [
+                {
+                    "mac_interface_map": [
+                        {
+                            "logical_nic_name": "eth0",
+                            "mac_address": "00:11:22:33:44:55",
+                        }
+                    ],
+                    "network_yaml": "old yaml content",
+                }
+            ]
+        )
+
+        result = add_or_update_static_host_config(
+            existing_static_network_config=existing_config,
+            dns_server="1.1.1.1",
+            mac_address="00:11:22:33:44:55",
+            ip_address="10.0.0.50",
+            subnet_prefix_len=16,
+            gateway_address="10.0.0.1",
+        )
+
+        assert len(result) == 1
+        assert result[0]["mac_interface_map"][0]["mac_address"] == "00:11:22:33:44:55"
+        assert "10.0.0.50" in result[0]["network_yaml"]
+        assert "1.1.1.1" in result[0]["network_yaml"]
+        assert "old yaml content" not in result[0]["network_yaml"]
+
+    def test_handle_invalid_json_config(self):
+        """Test handling of invalid JSON in existing config."""
+        with pytest.raises(json.JSONDecodeError):
+            add_or_update_static_host_config(
+                existing_static_network_config="invalid json",
+                dns_server="8.8.8.8",
+                mac_address="00:11:22:33:44:55",
+                ip_address="192.168.1.100",
+                subnet_prefix_len=24,
+                gateway_address="192.168.1.1",
+            )
+
+
+class TestRemoveStaticHostConfig:
+    """Test cases for remove_static_host_config function."""
+
+    def test_remove_existing_host_config(self):
+        """Test removing an existing host configuration."""
+        existing_config = json.dumps(
+            [
+                {
+                    "mac_interface_map": [
+                        {
+                            "logical_nic_name": "eth0",
+                            "mac_address": "00:11:22:33:44:55",
+                        }
+                    ],
+                    "network_yaml": "yaml1",
+                },
+                {
+                    "mac_interface_map": [
+                        {
+                            "logical_nic_name": "eth0",
+                            "mac_address": "aa:bb:cc:dd:ee:ff",
+                        }
+                    ],
+                    "network_yaml": "yaml2",
+                },
+            ]
+        )
+
+        result = remove_static_host_config(
+            existing_static_network_config=existing_config,
+            mac_address="00:11:22:33:44:55",
+        )
+
+        assert len(result) == 1
+        assert result[0]["mac_interface_map"][0]["mac_address"] == "aa:bb:cc:dd:ee:ff"
+        assert result[0]["network_yaml"] == "yaml2"
+
+    def test_remove_nonexistent_host_config(self):
+        """Test removing a host configuration that doesn't exist."""
+        existing_config = json.dumps(
+            [
+                {
+                    "mac_interface_map": [
+                        {
+                            "logical_nic_name": "eth0",
+                            "mac_address": "00:11:22:33:44:55",
+                        }
+                    ],
+                    "network_yaml": "yaml1",
+                }
+            ]
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="host config for mac address ff:ff:ff:ff:ff:ff does not exist",
+        ):
+            remove_static_host_config(
+                existing_static_network_config=existing_config,
+                mac_address="ff:ff:ff:ff:ff:ff",
+            )
+
+    def test_remove_from_empty_config(self):
+        """Test removing from an empty or None configuration."""
+        with pytest.raises(
+            ValueError,
+            match="host config for mac address 00:11:22:33:44:55 does not exist",
+        ):
+            remove_static_host_config(
+                existing_static_network_config=None,
+                mac_address="00:11:22:33:44:55",
+            )
+
+    def test_remove_last_host_config(self):
+        """Test removing the last host configuration from the list."""
+        existing_config = json.dumps(
+            [
+                {
+                    "mac_interface_map": [
+                        {
+                            "logical_nic_name": "eth0",
+                            "mac_address": "00:11:22:33:44:55",
+                        }
+                    ],
+                    "network_yaml": "yaml1",
+                }
+            ]
+        )
+
+        result = remove_static_host_config(
+            existing_static_network_config=existing_config,
+            mac_address="00:11:22:33:44:55",
+        )
+
+        assert len(result) == 0
+
+    def test_handle_invalid_json_config_in_remove(self):
+        """Test handling of invalid JSON in existing config during removal."""
+        with pytest.raises(json.JSONDecodeError):
+            remove_static_host_config(
+                existing_static_network_config="invalid json",
+                mac_address="00:11:22:33:44:55",
+            )


### PR DESCRIPTION
Right now it is pretty basic with just the ability to add basic network config with a predefined NMState template.

The API handling is a bit awkward given the MAC to IP mapping but all of that complexity is hidden from the LLM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Add host-level static networking tools: set IP, DNS, subnet prefix, and gateway; remove a host's static network config; list infrastructure environments for a cluster.
  - Automatically generate NMState YAML for configured hosts.

- **Tests**
  - Add comprehensive unit tests covering creation, update, removal, YAML generation, and error handling for static network configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->