### PR TITLE
MGMT-21787: Allow adding/updating platform to clusters

### DIFF
--- a/service_client/assisted_service_api.py
+++ b/service_client/assisted_service_api.py
@@ -17,6 +17,7 @@ from assisted_service_client import ApiClient, Configuration, api, models
 
 from service_client.logger import log
 from service_client.exceptions import sanitize_exceptions
+from service_client.helpers import Helpers
 from metrics.metrics import API_CALL_LATENCY
 
 T = TypeVar("T")
@@ -259,6 +260,9 @@ class InventoryClient:
             cluster_params["high_availability_mode"] = "None"
             cluster_params["user_managed_networking"] = True
 
+        platform = Helpers.get_platform_model(cluster_params.get("platform"))
+        cluster_params["platform"] = platform
+
         params = models.ClusterCreateParams(
             name=name,
             openshift_version=version,
@@ -346,6 +350,10 @@ class InventoryClient:
         Returns:
             models.Cluster: The updated cluster object.
         """
+        if "platform" in update_params:
+            platform = Helpers.get_platform_model(update_params["platform"])
+            update_params["platform"] = platform
+
         params = models.V2ClusterUpdateParams(**update_params)
         if api_vip != "":
             params.api_vips = [models.ApiVip(cluster_id=cluster_id, ip=api_vip)]

--- a/service_client/helpers.py
+++ b/service_client/helpers.py
@@ -1,0 +1,38 @@
+"""Helper functions for the service client."""
+
+from typing import Literal, Optional, cast, get_args
+from assisted_service_client import models
+
+
+class Helpers:
+    """Helpers contains functions that can be used by the service client."""
+
+    # Valid platform types for cluster creation and updates
+    VALID_PLATFORMS = Literal["baremetal", "vsphere", "oci", "nutanix", "none"]
+
+    @staticmethod
+    def get_platform_model(platform: Optional[str]) -> models.Platform:
+        """
+        Get the platform object from a platform type string.
+
+        Args:
+            platform (str): The platform type string
+
+        Returns:
+            models.Platform: The platform object
+
+        Raises:
+            ValueError: If the platform is invalid.
+        """
+        if platform is None or platform == "":
+            return models.Platform(type=cast(models.PlatformType, "baremetal"))
+        if platform == "oci":
+            return models.Platform(
+                type=cast(models.PlatformType, "external"),
+                external=models.PlatformExternal(
+                    platform_name="oci", cloud_controller_manager="External"
+                ),
+            )
+        if platform not in get_args(Helpers.VALID_PLATFORMS):
+            raise ValueError(f"Invalid platform {platform}")
+        return models.Platform(type=cast(models.PlatformType, platform))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,48 @@
+"""
+Unit tests for the service_client.helpers module.
+"""
+
+import pytest
+from service_client.helpers import Helpers
+
+
+class TestHelpers:
+    """Test cases for the Helpers class."""
+
+    @pytest.mark.asyncio
+    async def test_get_platform_model_default(self) -> None:
+        """Test get_platform_model with None or empty string returns baremetal."""
+        # Test with None
+        platform = Helpers.get_platform_model(None)
+        assert platform.type == "baremetal"
+        assert platform.external is None
+
+        # Test with empty string
+        platform = Helpers.get_platform_model("")
+        assert platform.type == "baremetal"
+        assert platform.external is None
+
+    @pytest.mark.asyncio
+    async def test_get_platform_model_oci(self) -> None:
+        """Test get_platform_model with oci platform."""
+        platform = Helpers.get_platform_model("oci")
+        assert platform.type == "external"
+        assert platform.external is not None
+        assert platform.external.platform_name == "oci"
+        assert platform.external.cloud_controller_manager == "External"
+
+    @pytest.mark.asyncio
+    async def test_get_platform_model_valid_platforms(self) -> None:
+        """Test get_platform_model with valid platform types."""
+        valid_platforms = ["baremetal", "vsphere", "nutanix", "none"]
+        for platform_type in valid_platforms:
+            platform = Helpers.get_platform_model(platform_type)
+            assert platform.type == platform_type
+            assert platform.external is None
+
+    @pytest.mark.asyncio
+    async def test_get_platform_model_invalid_platform(self) -> None:
+        """Test get_platform_model with invalid platform raises ValueError."""
+        with pytest.raises(ValueError) as err:
+            Helpers.get_platform_model("invalid_platform")
+        assert str(err.value) == "Invalid platform invalid_platform"


### PR DESCRIPTION
Introduces tools:
- list platforms available for a cluster
- update the platform for a cluster

Modifies tool:
- create cluster with platform argument

Adds a new Helper class to hold utility functions for the service client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Specify a platform when creating a cluster; sensible defaults and validations prevent invalid combinations. Platform is included in logs and cluster parameters. New operation to update a cluster's platform after creation.

- **Documentation**
  - Clarified VIP-related descriptions to reflect platform behavior.

- **Tests**
  - Added tests for platform handling in creation, updates, helper behavior, and platform validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->