### PR TITLE
Add metric param for static route templating

### DIFF
--- a/static_net/template.py
+++ b/static_net/template.py
@@ -5,6 +5,7 @@ from ipaddress import IPv4Address
 
 from pydantic import BaseModel, Field
 from jinja2 import Template
+import yaml
 
 
 class RouteParams(BaseModel):
@@ -22,6 +23,7 @@ class RouteParams(BaseModel):
     table_id: int | None = Field(
         254, description="The routing table id to add this route to"
     )
+    metric: int | None = Field(None, description="The route metric value")
 
 
 class IPV4AddressWithSubnet(BaseModel):
@@ -116,7 +118,8 @@ class NMStateTemplateParams(BaseModel):
 
 def generate_nmstate_from_template(params: NMStateTemplateParams) -> str:
     """Generate the nmstate yaml based on the params"""
-    return NMSTATE_TEMPLATE.render(params)
+    # Go through a serialization loop to standardize indentation and whitespace.
+    return yaml.dump(yaml.safe_load(NMSTATE_TEMPLATE.render(params)))
 
 
 NMSTATE_TEMPLATE = Template(
@@ -144,6 +147,9 @@ routes:
       next-hop-interface: {{r.next_hop_interface}}
       {% if r.table_id is not none %}
       table-id: {{r.table_id}}
+      {% endif %}
+      {% if r.metric is not none %}
+      metric: {{r.metric}}
       {% endif %}
   {% endfor %}
 {% endif %}

--- a/tests/test_static_net.py
+++ b/tests/test_static_net.py
@@ -347,6 +347,7 @@ class TestGenerateNmstateFromTemplate:
                     next_hop_address="192.168.1.1",
                     next_hop_interface="eth0",
                     table_id=254,
+                    metric=50,
                 )
             ],
             ethernet_ifaces=[
@@ -363,6 +364,7 @@ class TestGenerateNmstateFromTemplate:
         assert "next-hop-address: 192.168.1.1" in result
         assert "next-hop-interface: eth0" in result
         assert "table-id: 254" in result
+        assert "metric: 50" in result
 
         # Verify the generated YAML is valid
         yaml.safe_load(result)


### PR DESCRIPTION
For some reason, the bot has a hard time figuring out how to add this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added optional per-route routing metric; when provided it appears in generated static network configurations, otherwise existing outputs are unchanged.
  - Standardized YAML serialization for generated network files to ensure consistent indentation/whitespace.

- Tests
  - Updated tests to cover routing entries with metrics and to validate their presence and formatting in generated configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->