### PR TITLE
adding the ability to run the setpup, clean-up, and action scripts of…

### DIFF
--- a/tests/template.yaml
+++ b/tests/template.yaml
@@ -43,6 +43,8 @@ objects:
             value: ${AGENT_PORT}
           - name: UNIQUE_ID
             value: ${JOB_ID}
+          - name: OCM_BASE_URL
+            value: ${OCM_BASE_URL}
 
 parameters:
 - name: JOB_ID
@@ -64,3 +66,5 @@ parameters:
   value: gemini
 - name: GEMINI_API_SECRET_KEY_NAME
   value: api_key
+- name: OCM_BASE_URL
+  value: https://api.stage.openshift.com


### PR DESCRIPTION
adding the ability to run the setpup, clean-up, and action scripts of the evaluation tests to run not only in the stageing namespace of app-interface, but in the integration and production too

https://issues.redhat.com/browse/MGMT-21703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configurable OCM Base URL setting with a default of https://api.stage.openshift.com, enabling easier environment targeting without manual changes.

- Chores
  - Updated job configuration to include the new environment variable for the OCM Base URL, aligning defaults across environments and reducing setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->