### PR TITLE
Actually use FastMCP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "assisted-service-client>=2.41.0.post3",
-    "fastmcp>=2.8.0",
+    "fastmcp>=2.12.3",
     "netaddr>=1.3.0",
     "requests>=2.32.3",
     "retry>=0.9.2",

--- a/uv.lock
+++ b/uv.lock
@@ -134,7 +134,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "assisted-service-client", specifier = ">=2.41.0.post3" },
-    { name = "fastmcp", specifier = ">=2.8.0" },
+    { name = "fastmcp", specifier = ">=2.12.3" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "netaddr", specifier = ">=1.3.0" },
     { name = "prometheus-client", specifier = ">=0.22.1" },
@@ -482,11 +482,11 @@ wheels = [
 
 [[package]]
 name = "docutils"
-version = "0.22.1"
+version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/47/d869000fb74438584858acc628a364b277fc012695f0dfd513cb10f99768/docutils-0.22.1.tar.gz", hash = "sha256:d2fb50923a313532b6d41a77776d24cb459a594be9b7e4afa1fbcb5bda1893e6", size = 2291655, upload-time = "2025-09-17T17:58:45.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/c0/89fe6215b443b919cb98a5002e107cb5026854ed1ccb6b5833e0768419d1/docutils-0.22.2.tar.gz", hash = "sha256:9fdb771707c8784c8f2728b67cb2c691305933d68137ef95a75db5f4dfbc213d", size = 2289092, upload-time = "2025-09-20T17:55:47.994Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/dc/1948b90c5d9dbfa4d1fd3991013a042ba3ac62ebd3afdcb3fac08366e755/docutils-0.22.1-py3-none-any.whl", hash = "sha256:806e896f256a17466426544038f30cb860a99f5d4af640e36c284bfcb1824512", size = 638455, upload-time = "2025-09-17T17:58:42.498Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dd/f95350e853a4468ec37478414fc04ae2d61dad7a947b3015c3dcc51a09b9/docutils-0.22.2-py3-none-any.whl", hash = "sha256:b0e98d679283fc3bb0ead8a5da7f501baa632654e7056e9c5846842213d674d8", size = 632667, upload-time = "2025-09-20T17:55:43.052Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Previously we were installing the package but using the official SDK for of FastMCP 1.0. Using FastMCP directly gives us a lot more features should we need them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Streamable HTTP responses enabled by default for smoother, real-time interactions.

- Bug Fixes
  - More reliable token detection by consistently reading tokens from HTTP headers.
  - Session identifiers are no longer forwarded during tool calls, reducing exposure of sensitive data.

- Refactor
  - Simplified tool discovery for improved responsiveness and stability.

- Chores
  - Updated minimum fastmcp dependency to a newer compatible version.

- Tests
  - Tests updated to use payload-based dispatch and header-mocking for HTTP behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->