### PR TITLE
Handle Missing Openshift Version in list_clusters

### DIFF
--- a/server.py
+++ b/server.py
@@ -201,7 +201,7 @@ async def list_clusters() -> str:
         {
             "name": cluster["name"],
             "id": cluster["id"],
-            "openshift_version": cluster["openshift_version"],
+            "openshift_version": cluster.get("openshift_version", "Unknown"),
             "status": cluster["status"],
         }
         for cluster in clusters

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,7 @@ Unit tests for the server module.
 
 import json
 import os
+from copy import deepcopy
 from typing import Generator, Tuple
 from unittest.mock import Mock, patch, call
 
@@ -291,6 +292,12 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
                 "openshift_version": "4.17.1",
                 "status": "installing",
             },
+            {
+                "name": "cluster3",
+                "id": "id3",
+                # Missing openshift version
+                "status": "installing",
+            },
         ]
         mock_inventory_client.list_clusters.return_value = mock_clusters
 
@@ -299,8 +306,9 @@ class TestMCPToolFunctions:  # pylint: disable=too-many-public-methods
         ):
             result = await server.list_clusters()
 
-            expected_result = json.dumps(mock_clusters)
-            assert result == expected_result
+            expected_clusters = deepcopy(mock_clusters)
+            expected_clusters[2]["openshift_version"] = "Unknown"
+            assert json.loads(result) == expected_clusters
             mock_inventory_client.list_clusters.assert_called_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Apparently there are some clusters for which this does not exist and was causing an error when using the list_clusters tool.

This just replaces it with 'Unknown' if it is missing.