### PR TITLE
Feat/mcp apps UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@ wheels/
 
 # Performance test output
 performance_test_results*
+
+# Deployment manifests (contain secrets)
+deploy/
+
+# Test coverage data
+.coverage
+
+# Server log file
+assisted-service-mcp.log

--- a/assisted_service_mcp/src/api.py
+++ b/assisted_service_mcp/src/api.py
@@ -1,7 +1,7 @@
-"""FastAPI application setup for the Assisted Service MCP server.
+"""ASGI application setup for the Assisted Service MCP server.
 
-This module initializes the FastAPI app and sets up the MCP server
-with appropriate transport protocols.
+This module initializes the FastMCP server and creates an ASGI app
+for deployment with uvicorn or any ASGI server.
 """
 
 from assisted_service_mcp.src.mcp import AssistedServiceMCPServer
@@ -14,10 +14,7 @@ configure_logging()
 # Initialize the MCP server
 server = AssistedServiceMCPServer()
 
-# Choose the appropriate transport protocol based on settings
-if settings.TRANSPORT == "streamable-http":
-    app = server.mcp.streamable_http_app()
-    log.info("Using StreamableHTTP transport (stateless)")
-else:
-    app = server.mcp.sse_app()
-    log.info("Using SSE transport (stateful)")
+# Create ASGI app with appropriate transport
+stateless = settings.TRANSPORT == "streamable-http"
+app = server.mcp.http_app(stateless_http=stateless)
+log.info("Using %s transport", "stateless StreamableHTTP" if stateless else "StreamableHTTP")

--- a/assisted_service_mcp/src/mcp.py
+++ b/assisted_service_mcp/src/mcp.py
@@ -114,18 +114,20 @@ class AssistedServiceMCPServer:
         - Host management tools
         - Network configuration tools
         """
-        _inv = AppConfig(resource_uri=INVENTORY_RESOURCE_URI)
-        _cre = AppConfig(resource_uri=CREATOR_RESOURCE_URI)
-        _set = AppConfig(resource_uri=SETUP_RESOURCE_URI)
+        _model_and_app = ["app", "model"]
+        _inv = AppConfig(resource_uri=INVENTORY_RESOURCE_URI, visibility=_model_and_app)
+        _cre = AppConfig(resource_uri=CREATOR_RESOURCE_URI, visibility=_model_and_app)
+        _set = AppConfig(resource_uri=SETUP_RESOURCE_URI, visibility=_model_and_app)
 
-        # Unified tools: app= opens the UI widget for clients that
-        # support it; the tool function itself branches on ui_supported
-        # to decide whether to append text follow-ups.
+        # Widget-opening tools (app= renders a UI dashboard)
         self.mcp.tool(app=_inv)(self._wrap_tool(cluster_tools.list_clusters))
-        self.mcp.tool(app=_cre)(self._wrap_tool(cluster_tools.create_cluster))
+        self.mcp.tool(app=_cre)(
+            self._wrap_tool(cluster_tools.open_cluster_creator)
+        )
         self.mcp.tool(app=_set)(self._wrap_tool(host_tools.get_cluster_hosts))
 
         # Cluster management tools
+        self.mcp.tool()(self._wrap_tool(cluster_tools.create_cluster))
         self.mcp.tool()(self._wrap_tool(cluster_tools.cluster_info))
         self.mcp.tool()(self._wrap_tool(cluster_tools.set_cluster_vips))
         self.mcp.tool()(self._wrap_tool(cluster_tools.set_cluster_platform))

--- a/assisted_service_mcp/src/mcp.py
+++ b/assisted_service_mcp/src/mcp.py
@@ -7,8 +7,8 @@ from importlib import resources
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
-from fastmcp import FastMCP
-from fastmcp.apps import AppConfig, ResourceCSP
+from fastmcp import Context, FastMCP
+from fastmcp.apps import AppConfig, ResourceCSP, UI_EXTENSION_ID
 from assisted_service_mcp.src.logger import log
 
 # Import auth utilities
@@ -118,16 +118,15 @@ class AssistedServiceMCPServer:
         _cre = AppConfig(resource_uri=CREATOR_RESOURCE_URI)
         _set = AppConfig(resource_uri=SETUP_RESOURCE_URI)
 
-        # Widget-opening tools (app= makes them render a UI dashboard)
+        # Unified tools: app= opens the UI widget for clients that
+        # support it; the tool function itself branches on ui_supported
+        # to decide whether to append text follow-ups.
         self.mcp.tool(app=_inv)(self._wrap_tool(cluster_tools.list_clusters))
-        self.mcp.tool(app=_cre)(
-            self._wrap_tool(cluster_tools.load_creator_dashboard)
-        )
+        self.mcp.tool(app=_cre)(self._wrap_tool(cluster_tools.create_cluster))
         self.mcp.tool(app=_set)(self._wrap_tool(host_tools.get_cluster_hosts))
 
-        # Cluster management tools (called from within widgets or by LLM)
+        # Cluster management tools
         self.mcp.tool()(self._wrap_tool(cluster_tools.cluster_info))
-        self.mcp.tool()(self._wrap_tool(cluster_tools.create_cluster))
         self.mcp.tool()(self._wrap_tool(cluster_tools.set_cluster_vips))
         self.mcp.tool()(self._wrap_tool(cluster_tools.set_cluster_platform))
         self.mcp.tool()(self._wrap_tool(cluster_tools.install_cluster))
@@ -192,33 +191,43 @@ class AssistedServiceMCPServer:
     def _wrap_tool(
         self, tool_func: Callable[..., Awaitable[Any]]
     ) -> Callable[..., Awaitable[Any]]:
-        """Wrap a tool function to inject mcp and auth dependencies.
+        """Wrap a tool function to inject auth and UI-support dependencies.
+
+        The wrapper accepts a FastMCP ``Context`` (auto-injected by the
+        framework), resolves the access token and whether the connected
+        client supports MCP Apps UI, then forwards both to the inner
+        tool function as the first two positional args.
 
         Args:
-            tool_func: The tool function to wrap.
+            tool_func: The tool function to wrap.  Its signature must
+                start with ``(get_access_token_func, ui_supported, ...)``.
 
         Returns:
-            A wrapped async function that injects mcp and get_access_token.
+            A wrapped async function whose exposed signature has the
+            first two internal params stripped.
         """
 
         @wraps(tool_func)
-        async def wrapped(*args: Any, **kwargs: Any) -> Any:
+        async def wrapped(ctx: Context, *args: Any, **kwargs: Any) -> Any:
             token = await asyncio.to_thread(self._get_access_token)
-            result = await tool_func(lambda: token, *args, **kwargs)
+            ui_supported = ctx.client_supports_extension(UI_EXTENSION_ID)
+            result = await tool_func(lambda: token, ui_supported, *args, **kwargs)
             if isinstance(result, bytes):
                 result = result.decode("utf-8", errors="replace")
             return result
 
-        # Get the original function signature
         sig = inspect.signature(tool_func)
         params = list(sig.parameters.values())
 
-        # Remove the first parameter (auth token provider) since it's injected by the wrapper
-        if len(params) >= 1:
-            params = params[1:]
+        # Remove the first two parameters (auth token + ui_supported)
+        if len(params) >= 2:
+            params = params[2:]
 
-        # Create new signature with remaining parameters
-        new_sig = sig.replace(parameters=params)
+        # Prepend ctx: Context so FastMCP auto-injects it
+        ctx_param = inspect.Parameter(
+            "ctx", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=Context
+        )
+        new_sig = sig.replace(parameters=[ctx_param, *params])
         wrapped.__signature__ = new_sig  # type: ignore[attr-defined]
 
         return wrapped

--- a/assisted_service_mcp/src/mcp.py
+++ b/assisted_service_mcp/src/mcp.py
@@ -118,29 +118,35 @@ class AssistedServiceMCPServer:
         _cre = AppConfig(resource_uri=CREATOR_RESOURCE_URI)
         _set = AppConfig(resource_uri=SETUP_RESOURCE_URI)
 
-        # Cluster management tools
-        self.mcp.tool(app=_inv)(self._wrap_tool(cluster_tools.cluster_info))
+        # Widget-opening tools (app= makes them render a UI dashboard)
         self.mcp.tool(app=_inv)(self._wrap_tool(cluster_tools.list_clusters))
-        self.mcp.tool(app=_cre)(self._wrap_tool(cluster_tools.create_cluster))
-        self.mcp.tool(app=_set)(self._wrap_tool(cluster_tools.set_cluster_vips))
+        self.mcp.tool(app=_cre)(
+            self._wrap_tool(cluster_tools.load_creator_dashboard)
+        )
+        self.mcp.tool(app=_set)(self._wrap_tool(host_tools.get_cluster_hosts))
+
+        # Cluster management tools (called from within widgets or by LLM)
+        self.mcp.tool()(self._wrap_tool(cluster_tools.cluster_info))
+        self.mcp.tool()(self._wrap_tool(cluster_tools.create_cluster))
+        self.mcp.tool()(self._wrap_tool(cluster_tools.set_cluster_vips))
         self.mcp.tool()(self._wrap_tool(cluster_tools.set_cluster_platform))
-        self.mcp.tool(app=_set)(self._wrap_tool(cluster_tools.install_cluster))
+        self.mcp.tool()(self._wrap_tool(cluster_tools.install_cluster))
         self.mcp.tool()(self._wrap_tool(cluster_tools.set_cluster_ssh_key))
         if settings.ENABLE_TROUBLESHOOTING_TOOLS:
             self.mcp.tool()(self._wrap_tool(cluster_tools.analyze_cluster_logs))
 
         # Event monitoring tools
-        self.mcp.tool(app=_inv)(self._wrap_tool(event_tools.cluster_events))
+        self.mcp.tool()(self._wrap_tool(event_tools.cluster_events))
         self.mcp.tool()(self._wrap_tool(event_tools.host_events))
 
         # Download/URL tools
-        self.mcp.tool(app=_set)(
+        self.mcp.tool()(
             self._wrap_tool(download_tools.cluster_iso_download_url)
         )
         self.mcp.tool()(
             self._wrap_tool(download_tools.cluster_credentials_download_url)
         )
-        self.mcp.tool(app=_inv)(
+        self.mcp.tool()(
             self._wrap_tool(download_tools.cluster_logs_download_url)
         )
 
@@ -152,21 +158,15 @@ class AssistedServiceMCPServer:
         self.mcp.tool()(self._wrap_tool(operator_tools.add_operator_bundle_to_cluster))
 
         # Host management tools
-        self.mcp.tool(app=_set)(self._wrap_tool(host_tools.set_host_role))
-        self.mcp.tool(app=_set)(self._wrap_tool(host_tools.get_cluster_hosts))
+        self.mcp.tool()(self._wrap_tool(host_tools.set_host_role))
 
         # Installation progress
-        self.mcp.tool(app=_set)(
+        self.mcp.tool()(
             self._wrap_tool(cluster_tools.get_installation_progress)
         )
 
         # Health check
         self.mcp.tool()(self._wrap_tool(health_tools.check_prerequisites))
-
-        # UI dashboard trigger
-        self.mcp.tool(app=_cre)(
-            self._wrap_tool(cluster_tools.load_creator_dashboard)
-        )
 
         # Network configuration tools
         self.mcp.tool()(self._wrap_tool(network_tools.validate_nmstate_yaml))
@@ -203,9 +203,11 @@ class AssistedServiceMCPServer:
 
         @wraps(tool_func)
         async def wrapped(*args: Any, **kwargs: Any) -> Any:
-            # Generate token off the event loop; pass a cheap closure to tools
             token = await asyncio.to_thread(self._get_access_token)
-            return await tool_func(lambda: token, *args, **kwargs)
+            result = await tool_func(lambda: token, *args, **kwargs)
+            if isinstance(result, bytes):
+                result = result.decode("utf-8", errors="replace")
+            return result
 
         # Get the original function signature
         sig = inspect.signature(tool_func)

--- a/assisted_service_mcp/src/mcp.py
+++ b/assisted_service_mcp/src/mcp.py
@@ -3,9 +3,12 @@
 import asyncio
 import inspect
 from functools import wraps
+from importlib import resources
+from pathlib import Path
 from typing import Any, Awaitable, Callable
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
+from fastmcp.apps import AppConfig, ResourceCSP
 from assisted_service_mcp.src.logger import log
 
 # Import auth utilities
@@ -20,7 +23,40 @@ from assisted_service_mcp.src.tools import (
     version_tools,
     operator_tools,
     host_tools,
+    health_tools,
     network_tools,
+)
+
+# --- MCP Apps: UI resource URIs ---
+INVENTORY_RESOURCE_URI = "ui://cluster-inventory"
+CREATOR_RESOURCE_URI = "ui://cluster-creator"
+SETUP_RESOURCE_URI = "ui://cluster-setup"
+
+_APP_CSP = AppConfig(csp=ResourceCSP(resource_domains=["https://unpkg.com"]))
+
+
+def _load_html(package: str, filename: str) -> str:
+    """Load an HTML dashboard file from package data."""
+    try:
+        return (
+            resources.files(package)
+            .joinpath(filename)
+            .read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError, TypeError):
+        return (Path(__file__).parent / "tools" / filename).read_text(
+            encoding="utf-8"
+        )
+
+
+INVENTORY_HTML = _load_html(
+    "assisted_service_mcp.src.tools", "cluster_inventory.html"
+)
+CREATOR_HTML = _load_html(
+    "assisted_service_mcp.src.tools", "cluster_creator.html"
+)
+SETUP_HTML = _load_html(
+    "assisted_service_mcp.src.tools", "cluster_setup.html"
 )
 
 
@@ -34,25 +70,37 @@ class AssistedServiceMCPServer:
     def __init__(self) -> None:
         """Initialize the MCP server with assisted service tools."""
         try:
-            # Get transport configuration from settings
-            use_stateless_http = settings.TRANSPORT == "streamable-http"
-
             # Initialize FastMCP server
-            self.mcp = FastMCP(
-                "AssistedService",
-                host=settings.MCP_HOST,
-                stateless_http=use_stateless_http,
-            )
+            self.mcp = FastMCP("AssistedService")
             # Define auth helpers bound to this MCP instance
             self._get_offline_token = lambda: get_offline_token(self.mcp)
             self._get_access_token = lambda: get_access_token(
                 self.mcp, offline_token_func=self._get_offline_token
             )
+            self._register_ui_resources()
             self._register_mcp_tools()
             log.info("Assisted Service MCP Server initialized successfully")
         except Exception as e:
             log.exception("Failed to initialize Assisted Service MCP Server: %s", e)
             raise
+
+    def _register_ui_resources(self) -> None:
+        """Register MCP Apps UI dashboard resources."""
+
+        @self.mcp.resource(INVENTORY_RESOURCE_URI, app=_APP_CSP)
+        def cluster_inventory_ui() -> str:
+            """Cluster Inventory dashboard for browsing OpenShift clusters."""
+            return INVENTORY_HTML
+
+        @self.mcp.resource(CREATOR_RESOURCE_URI, app=_APP_CSP)
+        def cluster_creator_ui() -> str:
+            """Cluster Creator dashboard for creating new OpenShift clusters."""
+            return CREATOR_HTML
+
+        @self.mcp.resource(SETUP_RESOURCE_URI, app=_APP_CSP)
+        def cluster_setup_ui() -> str:
+            """Cluster Setup dashboard for host registration and installation."""
+            return SETUP_HTML
 
     def _register_mcp_tools(self) -> None:
         """Register MCP tools for assisted service operations.
@@ -66,39 +114,61 @@ class AssistedServiceMCPServer:
         - Host management tools
         - Network configuration tools
         """
-        # Register cluster management tools
-        self.mcp.tool()(self._wrap_tool(cluster_tools.cluster_info))
-        self.mcp.tool()(self._wrap_tool(cluster_tools.list_clusters))
-        self.mcp.tool()(self._wrap_tool(cluster_tools.create_cluster))
-        self.mcp.tool()(self._wrap_tool(cluster_tools.set_cluster_vips))
+        _inv = AppConfig(resource_uri=INVENTORY_RESOURCE_URI)
+        _cre = AppConfig(resource_uri=CREATOR_RESOURCE_URI)
+        _set = AppConfig(resource_uri=SETUP_RESOURCE_URI)
+
+        # Cluster management tools
+        self.mcp.tool(app=_inv)(self._wrap_tool(cluster_tools.cluster_info))
+        self.mcp.tool(app=_inv)(self._wrap_tool(cluster_tools.list_clusters))
+        self.mcp.tool(app=_cre)(self._wrap_tool(cluster_tools.create_cluster))
+        self.mcp.tool(app=_set)(self._wrap_tool(cluster_tools.set_cluster_vips))
         self.mcp.tool()(self._wrap_tool(cluster_tools.set_cluster_platform))
-        self.mcp.tool()(self._wrap_tool(cluster_tools.install_cluster))
+        self.mcp.tool(app=_set)(self._wrap_tool(cluster_tools.install_cluster))
         self.mcp.tool()(self._wrap_tool(cluster_tools.set_cluster_ssh_key))
         if settings.ENABLE_TROUBLESHOOTING_TOOLS:
             self.mcp.tool()(self._wrap_tool(cluster_tools.analyze_cluster_logs))
 
-        # Register event monitoring tools
-        self.mcp.tool()(self._wrap_tool(event_tools.cluster_events))
+        # Event monitoring tools
+        self.mcp.tool(app=_inv)(self._wrap_tool(event_tools.cluster_events))
         self.mcp.tool()(self._wrap_tool(event_tools.host_events))
 
-        # Register download/URL tools
-        self.mcp.tool()(self._wrap_tool(download_tools.cluster_iso_download_url))
+        # Download/URL tools
+        self.mcp.tool(app=_set)(
+            self._wrap_tool(download_tools.cluster_iso_download_url)
+        )
         self.mcp.tool()(
             self._wrap_tool(download_tools.cluster_credentials_download_url)
         )
-        self.mcp.tool()(self._wrap_tool(download_tools.cluster_logs_download_url))
+        self.mcp.tool(app=_inv)(
+            self._wrap_tool(download_tools.cluster_logs_download_url)
+        )
 
-        # Register version tools
+        # Version tools
         self.mcp.tool()(self._wrap_tool(version_tools.list_versions))
 
-        # Register operator bundle tools
+        # Operator bundle tools
         self.mcp.tool()(self._wrap_tool(operator_tools.list_operator_bundles))
         self.mcp.tool()(self._wrap_tool(operator_tools.add_operator_bundle_to_cluster))
 
-        # Register host management tools
-        self.mcp.tool()(self._wrap_tool(host_tools.set_host_role))
+        # Host management tools
+        self.mcp.tool(app=_set)(self._wrap_tool(host_tools.set_host_role))
+        self.mcp.tool(app=_set)(self._wrap_tool(host_tools.get_cluster_hosts))
 
-        # Register network configuration tools
+        # Installation progress
+        self.mcp.tool(app=_set)(
+            self._wrap_tool(cluster_tools.get_installation_progress)
+        )
+
+        # Health check
+        self.mcp.tool()(self._wrap_tool(health_tools.check_prerequisites))
+
+        # UI dashboard trigger
+        self.mcp.tool(app=_cre)(
+            self._wrap_tool(cluster_tools.load_creator_dashboard)
+        )
+
+        # Network configuration tools
         self.mcp.tool()(self._wrap_tool(network_tools.validate_nmstate_yaml))
         self.mcp.tool(
             description=f"""

--- a/assisted_service_mcp/src/tools/cluster_creator.html
+++ b/assisted_service_mcp/src/tools/cluster_creator.html
@@ -380,9 +380,16 @@
       window.mcpApp = app;
     });
 
+    function stripFollowUps(raw) {
+      if (!raw) return raw;
+      const idx = raw.indexOf("\n\n[IMPORTANT");
+      return idx !== -1 ? raw.substring(0, idx) : raw;
+    }
+
     async function callTool(name, args = {}) {
       const result = await window.mcpApp.callServerTool({ name, arguments: args });
-      const text = result.content?.find(c => c.type === "text")?.text;
+      const raw = result.content?.find(c => c.type === "text")?.text;
+      const text = stripFollowUps(raw);
       if (!text) return null;
       try { return JSON.parse(text); } catch { return text; }
     }

--- a/assisted_service_mcp/src/tools/cluster_creator.html
+++ b/assisted_service_mcp/src/tools/cluster_creator.html
@@ -1,0 +1,424 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cluster Creator</title>
+  <style>
+    :root {
+      --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      --color-primary: #06c;
+      --color-success: #3e8635;
+      --color-error: #c9190b;
+      --color-text: #151515;
+      --color-muted: #6a6e73;
+      --color-border: #d2d2d2;
+      --color-bg: #f8f8f8;
+      --color-surface: #ffffff;
+      --radius: 0.375rem;
+      --radius-sm: 0.25rem;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: var(--font-body);
+      font-size: 14px;
+      color: var(--color-text);
+      background: var(--color-bg);
+      line-height: 1.5;
+    }
+
+    .shell {
+      max-width: 540px;
+      margin: 0 auto;
+      padding: 1.25rem;
+    }
+
+    .header { margin-bottom: 1rem; }
+
+    .header h1 {
+      margin: 0;
+      font-size: 1.15rem;
+      font-weight: 600;
+    }
+
+    .card {
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius);
+      padding: 1.25rem;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+    }
+
+    .form-group {
+      margin-bottom: 1rem;
+    }
+
+    .form-group:last-of-type {
+      margin-bottom: 0;
+    }
+
+    label {
+      display: block;
+      font-weight: 600;
+      font-size: 0.85rem;
+      margin-bottom: 0.3rem;
+    }
+
+    .hint {
+      display: block;
+      font-size: 0.78rem;
+      color: var(--color-muted);
+      margin-bottom: 0.3rem;
+    }
+
+    input[type="text"], select {
+      width: 100%;
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-sm);
+      padding: 0.5rem 0.65rem;
+      font: inherit;
+      color: var(--color-text);
+      background: var(--color-surface);
+    }
+
+    input[type="text"]:focus, select:focus {
+      outline: 2px solid var(--color-primary);
+      outline-offset: -1px;
+      border-color: var(--color-primary);
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      border: 1px solid transparent;
+      border-radius: var(--radius-sm);
+      padding: 0.45rem 1rem;
+      font: inherit;
+      font-weight: 600;
+      font-size: 0.85rem;
+      cursor: pointer;
+      transition: opacity 0.15s;
+    }
+
+    .btn:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+
+    .btn-primary {
+      background: var(--color-primary);
+      color: #fff;
+    }
+
+    .btn-primary:hover:not(:disabled) {
+      opacity: 0.9;
+    }
+
+    .btn-secondary {
+      background: var(--color-surface);
+      color: var(--color-text);
+      border-color: var(--color-border);
+    }
+
+    .btn-secondary:hover:not(:disabled) {
+      background: var(--color-bg);
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 1.25rem;
+    }
+
+    .error-banner {
+      background: #faeae8;
+      border-left: 3px solid var(--color-error);
+      border-radius: var(--radius-sm);
+      padding: 0.6rem 0.85rem;
+      margin-bottom: 1rem;
+      font-size: 0.85rem;
+      color: var(--color-error);
+    }
+
+    .success-card {
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius);
+      padding: 1.25rem;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+    }
+
+    .success-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+
+    .success-icon {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: #edf8ef;
+      color: var(--color-success);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1rem;
+      flex-shrink: 0;
+    }
+
+    .success-header h2 {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--color-success);
+    }
+
+    .detail-grid {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 0.35rem 1rem;
+      font-size: 0.88rem;
+      margin-bottom: 1rem;
+    }
+
+    .detail-grid dt {
+      font-weight: 600;
+      color: var(--color-muted);
+      white-space: nowrap;
+    }
+
+    .detail-grid dd {
+      margin: 0;
+    }
+
+    .mono {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      background: var(--color-bg);
+      padding: 0.15rem 0.4rem;
+      border-radius: var(--radius-sm);
+    }
+
+    .status-badge {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      font-size: 0.78rem;
+      font-weight: 600;
+      background: #edf8ef;
+      color: var(--color-success);
+    }
+
+    .spinner {
+      display: inline-block;
+      width: 14px;
+      height: 14px;
+      border: 2px solid rgba(255,255,255,0.3);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: spin 0.6s linear infinite;
+    }
+
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    .hidden { display: none !important; }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <div class="header">
+      <h1>Create Cluster</h1>
+    </div>
+
+    <div id="error-banner" class="error-banner hidden"></div>
+
+    <!-- Creation Form -->
+    <div id="view-form" class="card">
+      <div class="form-group">
+        <label for="cluster-name">Cluster Name</label>
+        <span class="hint">Lowercase letters, numbers, and hyphens (max 54 chars)</span>
+        <input type="text" id="cluster-name" maxlength="54" placeholder="my-cluster" required>
+      </div>
+
+      <div class="form-group">
+        <label for="ocp-version">OpenShift Version</label>
+        <select id="ocp-version">
+          <option value="4.21" selected>4.21</option>
+          <option value="4.20">4.20</option>
+          <option value="4.19">4.19</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label for="base-domain">Base DNS Domain</label>
+        <span class="hint">e.g. example.com</span>
+        <input type="text" id="base-domain" placeholder="example.com" required>
+      </div>
+
+      <div class="form-group">
+        <label for="deploy-type">Deployment Type</label>
+        <select id="deploy-type">
+          <option value="false" selected>Full HA (3+ control planes)</option>
+          <option value="true">Single Node (SNO)</option>
+        </select>
+      </div>
+
+      <div class="actions">
+        <button id="btn-create" class="btn btn-primary" disabled>Create Cluster</button>
+      </div>
+    </div>
+
+    <!-- Success View -->
+    <div id="view-success" class="success-card hidden">
+      <div class="success-header">
+        <div class="success-icon">&#10003;</div>
+        <h2>Cluster Created</h2>
+      </div>
+
+      <dl class="detail-grid">
+        <dt>Name</dt>
+        <dd id="res-name"></dd>
+        <dt>Cluster ID</dt>
+        <dd><span id="res-id" class="mono"></span></dd>
+        <dt>Status</dt>
+        <dd><span id="res-status" class="status-badge"></span></dd>
+      </dl>
+
+      <div class="actions">
+        <button id="btn-setup" class="btn btn-primary">Continue to Setup</button>
+        <button id="btn-inventory" class="btn btn-secondary">View in Inventory</button>
+      </div>
+    </div>
+  </div>
+
+  <script type="module">
+    const $ = (sel) => document.querySelector(sel);
+
+    const elName     = $("#cluster-name");
+    const elVersion  = $("#ocp-version");
+    const elDomain   = $("#base-domain");
+    const elDeploy   = $("#deploy-type");
+    const elBtnCreate = $("#btn-create");
+    const elError    = $("#error-banner");
+    const elFormView = $("#view-form");
+    const elSuccessView = $("#view-success");
+    const elResName  = $("#res-name");
+    const elResId    = $("#res-id");
+    const elResStatus = $("#res-status");
+    const elBtnSetup = $("#btn-setup");
+    const elBtnInventory = $("#btn-inventory");
+
+    let createdClusterId = null;
+
+    // --- MCP SDK ---
+    import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
+      const App = module.App || module.default?.App || module.default;
+      const app = new (App.App || App)({ name: "Cluster Creator", version: "1.0.0" });
+      app.connect();
+      window.mcpApp = app;
+    });
+
+    async function callTool(name, args = {}) {
+      const result = await window.mcpApp.callServerTool({ name, arguments: args });
+      const text = result.content?.find(c => c.type === "text")?.text;
+      if (!text) return null;
+      try { return JSON.parse(text); } catch { return text; }
+    }
+
+    // --- Validation ---
+    function updateCreateBtn() {
+      const valid = elName.value.trim().length > 0 && elDomain.value.trim().length > 0;
+      elBtnCreate.disabled = !valid;
+    }
+
+    elName.addEventListener("input", updateCreateBtn);
+    elDomain.addEventListener("input", updateCreateBtn);
+
+    function showError(msg) {
+      elError.textContent = msg;
+      elError.classList.remove("hidden");
+    }
+
+    function hideError() {
+      elError.classList.add("hidden");
+      elError.textContent = "";
+    }
+
+    // --- Create ---
+    elBtnCreate.addEventListener("click", async () => {
+      hideError();
+
+      const name       = elName.value.trim();
+      const version    = elVersion.value;
+      const baseDomain = elDomain.value.trim();
+      const singleNode = elDeploy.value === "true";
+
+      elBtnCreate.disabled = true;
+      elBtnCreate.innerHTML = '<span class="spinner"></span> Creating\u2026';
+
+      try {
+        const result = await callTool("create_cluster", {
+          name,
+          version,
+          base_domain: baseDomain,
+          single_node: singleNode,
+        });
+
+        if (!result) {
+          showError("No response from cluster creation tool.");
+          elBtnCreate.textContent = "Create Cluster";
+          updateCreateBtn();
+          return;
+        }
+
+        const clusterId = typeof result === "string"
+          ? result
+          : result.id || result.cluster_id || result.uuid || JSON.stringify(result);
+
+        createdClusterId = clusterId;
+
+        elResName.textContent = name;
+        elResId.textContent = clusterId;
+        elResStatus.textContent = "pending-for-input";
+
+        elFormView.classList.add("hidden");
+        elSuccessView.classList.remove("hidden");
+        hideError();
+      } catch (err) {
+        showError(err.message || "Cluster creation failed. Please try again.");
+        elBtnCreate.textContent = "Create Cluster";
+        updateCreateBtn();
+      }
+    });
+
+    // --- Post-creation actions ---
+    elBtnSetup.addEventListener("click", async () => {
+      if (!createdClusterId || !window.mcpApp) return;
+      try {
+        await window.mcpApp.sendMessage({
+          role: "user",
+          content: [{ type: "text", text: `Set up cluster (ID: ${createdClusterId})` }],
+        });
+      } catch { /* user can type it manually */ }
+    });
+
+    elBtnInventory.addEventListener("click", async () => {
+      if (!window.mcpApp) return;
+      try {
+        await window.mcpApp.sendMessage({
+          role: "user",
+          content: [{ type: "text", text: "Show cluster inventory" }],
+        });
+      } catch { /* user can type it manually */ }
+    });
+  </script>
+</body>
+</html>

--- a/assisted_service_mcp/src/tools/cluster_creator.html
+++ b/assisted_service_mcp/src/tools/cluster_creator.html
@@ -3,9 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark" />
   <title>Cluster Creator</title>
   <style>
     :root {
+      color-scheme: light dark;
       --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
       --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       --color-primary: #06c;
@@ -20,14 +22,28 @@
       --radius-sm: 0.25rem;
     }
 
+    [data-theme="dark"] {
+      --color-primary: #4da3ff;
+      --color-success: #5cb85c;
+      --color-error: #f06560;
+      --color-text: #e0e0e0;
+      --color-muted: #a0a0a0;
+      --color-border: #444;
+      --color-bg: #1e1e1e;
+      --color-surface: #2a2a2a;
+      --bg-banner-success: #1a2e1a;
+      --bg-banner-error: #2e1a1a;
+    }
+
     *, *::before, *::after { box-sizing: border-box; }
+
+    html, body { background: transparent; }
 
     body {
       margin: 0;
       font-family: var(--font-body);
       font-size: 14px;
       color: var(--color-text);
-      background: var(--color-bg);
       line-height: 1.5;
     }
 
@@ -137,7 +153,7 @@
     }
 
     .error-banner {
-      background: #faeae8;
+      background: var(--bg-banner-error, #faeae8);
       border-left: 3px solid var(--color-error);
       border-radius: var(--radius-sm);
       padding: 0.6rem 0.85rem;
@@ -165,7 +181,7 @@
       width: 28px;
       height: 28px;
       border-radius: 50%;
-      background: #edf8ef;
+      background: var(--bg-banner-success, #edf8ef);
       color: var(--color-success);
       display: flex;
       align-items: center;
@@ -213,7 +229,7 @@
       border-radius: 999px;
       font-size: 0.78rem;
       font-weight: 600;
-      background: #edf8ef;
+      background: var(--bg-banner-success, #edf8ef);
       color: var(--color-success);
     }
 
@@ -230,6 +246,31 @@
     @keyframes spin { to { transform: rotate(360deg); } }
 
     .hidden { display: none !important; }
+
+    .follow-ups {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 16px;
+      padding-top: 12px;
+      border-top: 1px solid var(--color-border);
+    }
+
+    .follow-ups button {
+      background: var(--color-surface);
+      color: var(--color-text);
+      border: 1px solid var(--color-border);
+      border-radius: 999px;
+      padding: 6px 14px;
+      font-size: 12px;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+    }
+
+    .follow-ups button:hover {
+      border-color: var(--color-primary);
+      color: var(--color-primary);
+    }
   </style>
 </head>
 <body>
@@ -296,6 +337,7 @@
         <button id="btn-setup" class="btn btn-primary">Continue to Setup</button>
         <button id="btn-inventory" class="btn btn-secondary">View in Inventory</button>
       </div>
+      <div id="creator-follow-ups"></div>
     </div>
   </div>
 
@@ -322,7 +364,19 @@
     import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
       const App = module.App || module.default?.App || module.default;
       const app = new (App.App || App)({ name: "Cluster Creator", version: "1.0.0" });
-      app.connect();
+      const applyDocTheme = module.applyDocumentTheme || module.default?.applyDocumentTheme;
+      const applyStyles = module.applyHostStyleVariables || module.default?.applyHostStyleVariables;
+      app.connect().then(() => {
+        try {
+          const ctx = app.getHostContext?.();
+          if (ctx?.theme && applyDocTheme) applyDocTheme(ctx.theme);
+          if (ctx?.styles?.variables && applyStyles) applyStyles(ctx.styles.variables);
+        } catch {}
+      });
+      app.onhostcontextchanged = (ctx) => {
+        if (ctx.theme && applyDocTheme) applyDocTheme(ctx.theme);
+        if (ctx?.styles?.variables && applyStyles) applyStyles(ctx.styles.variables);
+      };
       window.mcpApp = app;
     });
 
@@ -392,6 +446,13 @@
         elFormView.classList.add("hidden");
         elSuccessView.classList.remove("hidden");
         hideError();
+
+        const fu = document.getElementById("creator-follow-ups");
+        fu.innerHTML = "";
+        renderFollowUps(fu, [
+          "Continue to the cluster setup wizard to register hosts and configure networking",
+          "Show this cluster in the inventory",
+        ]);
       } catch (err) {
         showError(err.message || "Cluster creation failed. Please try again.");
         elBtnCreate.textContent = "Create Cluster";
@@ -405,7 +466,7 @@
       try {
         await window.mcpApp.sendMessage({
           role: "user",
-          content: [{ type: "text", text: `Set up cluster (ID: ${createdClusterId})` }],
+          content: [{ type: "text", text: `Call get_cluster_hosts with cluster_id ${createdClusterId} to open the cluster setup dashboard` }],
         });
       } catch { /* user can type it manually */ }
     });
@@ -419,6 +480,29 @@
         });
       } catch { /* user can type it manually */ }
     });
+
+    async function suggestFollowUp(promptText) {
+      if (window.openai?.sendFollowUpMessage) {
+        await window.openai.sendFollowUpMessage({ prompt: promptText });
+      } else if (window.mcpApp) {
+        await window.mcpApp.sendMessage({
+          role: "user",
+          content: [{ type: "text", text: promptText }]
+        });
+      }
+    }
+
+    function renderFollowUps(container, prompts) {
+      const div = document.createElement("div");
+      div.className = "follow-ups";
+      for (const prompt of prompts) {
+        const btn = document.createElement("button");
+        btn.textContent = prompt;
+        btn.onclick = () => suggestFollowUp(prompt);
+        div.appendChild(btn);
+      }
+      container.appendChild(div);
+    }
   </script>
 </body>
 </html>

--- a/assisted_service_mcp/src/tools/cluster_creator.html
+++ b/assisted_service_mcp/src/tools/cluster_creator.html
@@ -380,9 +380,15 @@
       window.mcpApp = app;
     });
 
+    function stripFollowUps(raw) {
+      if (!raw) return raw;
+      const idx = raw.indexOf("\n\n[IMPORTANT");
+      return idx !== -1 ? raw.substring(0, idx) : raw;
+    }
+
     async function callTool(name, args = {}) {
       const result = await window.mcpApp.callServerTool({ name, arguments: args });
-      const text = result.content?.find(c => c.type === "text")?.text;
+      const text = stripFollowUps(result.content?.find(c => c.type === "text")?.text);
       if (!text) return null;
       try { return JSON.parse(text); } catch { return text; }
     }

--- a/assisted_service_mcp/src/tools/cluster_creator.html
+++ b/assisted_service_mcp/src/tools/cluster_creator.html
@@ -380,16 +380,9 @@
       window.mcpApp = app;
     });
 
-    function stripFollowUps(raw) {
-      if (!raw) return raw;
-      const idx = raw.indexOf("\n\n[IMPORTANT");
-      return idx !== -1 ? raw.substring(0, idx) : raw;
-    }
-
     async function callTool(name, args = {}) {
       const result = await window.mcpApp.callServerTool({ name, arguments: args });
-      const raw = result.content?.find(c => c.type === "text")?.text;
-      const text = stripFollowUps(raw);
+      const text = result.content?.find(c => c.type === "text")?.text;
       if (!text) return null;
       try { return JSON.parse(text); } catch { return text; }
     }

--- a/assisted_service_mcp/src/tools/cluster_inventory.html
+++ b/assisted_service_mcp/src/tools/cluster_inventory.html
@@ -820,8 +820,8 @@ function renderDetailView(details, title) {
   const actionsDiv = document.getElementById("detail-actions");
   actionsDiv.innerHTML = "";
 
-  const status = (details["Status"] || "").toLowerCase();
-  if (SETUP_STATUSES.includes(status)) {
+  const clusterStatus = (details["Status"] || "").toLowerCase();
+  if (SETUP_STATUSES.includes(clusterStatus)) {
     const setupBtn = document.createElement("button");
     setupBtn.className = "success";
     setupBtn.textContent = "Setup Cluster";
@@ -842,12 +842,12 @@ function renderDetailView(details, title) {
 
   const fu = document.getElementById("detail-follow-ups");
   fu.innerHTML = "";
-  const status = (details["Status"] || "").toLowerCase();
+  const detailStatus = (details["Status"] || "").toLowerCase();
   const prompts = [];
-  if (["pending-for-input", "insufficient", "ready"].includes(status)) {
+  if (["pending-for-input", "insufficient", "ready"].includes(detailStatus)) {
     prompts.push("Set up this cluster");
   }
-  if (["installing"].includes(status)) {
+  if (["installing"].includes(detailStatus)) {
     prompts.push("Check the installation progress");
   }
   prompts.push("Show cluster events for troubleshooting");
@@ -1032,12 +1032,10 @@ function initMcp(module) {
   const App = module.App || module.default?.App || module.default;
   const AppClass = App.App || App;
   const app = new AppClass({ name: "Cluster Inventory", version: "1.0.0" });
+  app.connect().then(() => applyTheme(module, app));
   window.mcpApp = app;
-  app.connect().then(() => {
-    applyTheme(module, app);
-    mcpReady = true;
-    loadClusters();
-  });
+  mcpReady = true;
+  loadClusters();
 }
 
 import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(initMcp).catch(err => {

--- a/assisted_service_mcp/src/tools/cluster_inventory.html
+++ b/assisted_service_mcp/src/tools/cluster_inventory.html
@@ -3,9 +3,11 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="color-scheme" content="light dark" />
 <title>Cluster Inventory</title>
 <style>
 :root {
+  color-scheme: light dark;
   --font-family: var(--pf-v5-global--FontFamily--text, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif);
   --color-primary: #06c;
   --color-success: #3e8635;
@@ -19,10 +21,31 @@
   --color-hover-row: #f0f0f0;
 }
 
+[data-theme="dark"] {
+  --color-bg: #1e1e1e;
+  --color-bg-alt: #2a2a2a;
+  --color-border: #444;
+  --color-text: #e0e0e0;
+  --color-text-secondary: #a0a0a0;
+  --color-hover-row: #333;
+  --color-primary: #4da3ff;
+  --color-success: #5cb85c;
+  --color-error: #f06560;
+  --color-warning: #f5c242;
+  --bg-banner-info: #1a2a3a;
+  --bg-banner-success: #1a2e1a;
+  --bg-banner-error: #2e1a1a;
+  --bg-banner-warning: #2e2a1a;
+}
+
 * {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
+}
+
+html, body {
+  background: transparent;
 }
 
 body {
@@ -30,7 +53,6 @@ body {
   font-size: 14px;
   line-height: 1.5;
   color: var(--color-text);
-  background: var(--color-bg);
   padding: 16px;
 }
 
@@ -66,25 +88,25 @@ body {
 }
 
 .banner.loading {
-  background: #e7f1fa;
+  background: var(--bg-banner-info, #e7f1fa);
   border: 1px solid var(--color-primary);
   color: var(--color-primary);
 }
 
 .banner.success {
-  background: #e9f7e9;
+  background: var(--bg-banner-success, #e9f7e9);
   border: 1px solid var(--color-success);
   color: var(--color-success);
 }
 
 .banner.error {
-  background: #fce8e8;
+  background: var(--bg-banner-error, #fce8e8);
   border: 1px solid var(--color-error);
   color: var(--color-error);
 }
 
 .banner.warning {
-  background: #fef6e0;
+  background: var(--bg-banner-warning, #fef6e0);
   border: 1px solid var(--color-warning);
   color: #795600;
 }
@@ -212,22 +234,22 @@ tr:hover td {
 }
 
 .status-ready, .status-installed, .status-adding-hosts {
-  background: #e9f7e9;
+  background: var(--bg-banner-success, #e9f7e9);
   color: var(--color-success);
 }
 
 .status-error, .status-cancelled {
-  background: #fce8e8;
+  background: var(--bg-banner-error, #fce8e8);
   color: var(--color-error);
 }
 
 .status-pending-for-input, .status-insufficient {
-  background: #fef6e0;
-  color: #795600;
+  background: var(--bg-banner-warning, #fef6e0);
+  color: var(--color-warning);
 }
 
 .status-installing, .status-preparing-for-installation, .status-finalizing {
-  background: #e7f1fa;
+  background: var(--bg-banner-info, #e7f1fa);
   color: var(--color-primary);
 }
 
@@ -350,7 +372,7 @@ tr:hover td {
 }
 
 .logs-link:hover {
-  background: #e7f1fa;
+  background: var(--bg-banner-info, #e7f1fa);
 }
 
 .empty-state {
@@ -385,6 +407,32 @@ tr:hover td {
   margin-left: 8px;
   font-weight: 400;
 }
+
+.follow-ups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border);
+}
+
+.follow-ups button {
+  background: var(--color-bg-alt);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.follow-ups button:hover {
+  background: var(--color-hover-row);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
 </style>
 </head>
 <body>
@@ -415,14 +463,12 @@ tr:hover td {
         <tr>
           <th>Name</th>
           <th>Status</th>
-          <th>Version</th>
-          <th>ID</th>
-          <th>Actions</th>
         </tr>
       </thead>
       <tbody id="cluster-tbody"></tbody>
     </table>
   </div>
+  <div id="list-follow-ups"></div>
 </div>
 
 <!-- Detail View -->
@@ -450,6 +496,7 @@ tr:hover td {
     <button onclick="loadLogs()" id="load-logs-btn">Download Logs</button>
     <div id="logs-container" style="margin-top:8px"></div>
   </div>
+  <div id="detail-follow-ups"></div>
 </div>
 
 <script type="module">
@@ -541,26 +588,60 @@ function parseClusterList(text) {
 
 function parseClusterDetail(text) {
   if (!text) return {};
-  if (typeof text === "object") return text;
+  if (typeof text === "object" && !Array.isArray(text)) {
+    return extractKnownFields(text);
+  }
 
-  const details = {};
-  const lines = text.split("\n");
+  const raw = String(text);
+  const fields = {};
 
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
+  const patterns = [
+    ["Version", /'openshift_version'\s*:\s*'([^']+)'/],
+    ["Base DNS Domain", /'base_dns_domain'\s*:\s*'([^']+)'/],
+    ["HA Mode", /'high_availability_mode'\s*:\s*'([^']+)'/],
+    ["CPU Architecture", /'cpu_architecture'\s*:\s*'([^']+)'/],
+    ["Network Type", /'network_type'\s*:\s*'([^']+)'/],
+    ["User", /'user_name'\s*:\s*'([^']+)'/],
+    ["Created", /'created_at'\s*:\s*datetime\.datetime\(([^)]+)\)/],
+    ["Control Plane Count", /'control_plane_count'\s*:\s*(\d+)/],
+    ["User Managed Networking", /'user_managed_networking'\s*:\s*(True|False)/],
+    ["Hyperthreading", /'hyperthreading'\s*:\s*'([^']+)'/],
+  ];
 
-    const colonIdx = trimmed.indexOf(":");
-    if (colonIdx > 0) {
-      let key = trimmed.substring(0, colonIdx).replace(/^[-*]\s*/, "").trim();
-      const value = trimmed.substring(colonIdx + 1).trim();
-      if (key && value) {
-        details[key] = value;
+  for (const [label, regex] of patterns) {
+    const match = raw.match(regex);
+    if (match && match[1]) {
+      let val = match[1];
+      if (label === "Created") {
+        const parts = val.split(",").map(s => s.trim());
+        if (parts.length >= 3) val = `${parts[0]}-${parts[1].padStart(2,"0")}-${parts[2].padStart(2,"0")}`;
       }
+      fields[label] = val;
     }
   }
 
-  return details;
+  const cidrMatch = raw.match(/'cluster_networks'\s*:\s*\[\{[^}]*'cidr'\s*:\s*'([^']+)'/);
+  if (cidrMatch) fields["Cluster Network CIDR"] = cidrMatch[1];
+  const svcMatch = raw.match(/'service_networks'\s*:\s*\[\{[^}]*'cidr'\s*:\s*'([^']+)'/);
+  if (svcMatch) fields["Service Network CIDR"] = svcMatch[1];
+
+  return fields;
+}
+
+function extractKnownFields(obj) {
+  const fields = {};
+  const map = {
+    name: "Name", id: "ID", status: "Status", openshift_version: "Version",
+    base_dns_domain: "Base DNS Domain", high_availability_mode: "HA Mode",
+    cpu_architecture: "CPU Architecture", network_type: "Network Type",
+    user_name: "User", control_plane_count: "Control Plane Count",
+  };
+  for (const [k, label] of Object.entries(map)) {
+    if (obj[k] !== undefined && obj[k] !== null && obj[k] !== "") {
+      fields[label] = String(obj[k]);
+    }
+  }
+  return fields;
 }
 
 function getStatusClass(status) {
@@ -607,38 +688,15 @@ function renderTable() {
     badge.textContent = cluster.status || "unknown";
     statusTd.appendChild(badge);
 
-    const versionTd = document.createElement("td");
-    versionTd.textContent = cluster.openshift_version || "-";
-
-    const idTd = document.createElement("td");
-    idTd.className = "id-cell";
-    idTd.textContent = cluster.id || "-";
-    idTd.title = cluster.id || "";
-
-    const actionsTd = document.createElement("td");
-    if (SETUP_STATUSES.includes((cluster.status || "").toLowerCase())) {
-      const setupBtn = document.createElement("button");
-      setupBtn.className = "success";
-      setupBtn.textContent = "Setup";
-      setupBtn.onclick = (e) => {
-        e.stopPropagation();
-        sendSetupMessage(cluster);
-      };
-      actionsTd.appendChild(setupBtn);
-    }
-
     tr.appendChild(nameTd);
     tr.appendChild(statusTd);
-    tr.appendChild(versionTd);
-    tr.appendChild(idTd);
-    tr.appendChild(actionsTd);
     tbody.appendChild(tr);
   }
 }
 
 function sendSetupMessage(cluster) {
   if (!window.mcpApp) return;
-  const msg = `Set up cluster ${cluster.name} (ID: ${cluster.id})`;
+  const msg = `Call get_cluster_hosts with cluster_id ${cluster.id} to open the cluster setup dashboard for ${cluster.name}`;
   window.mcpApp.sendMessage({
     role: "user",
     content: [{ type: "text", text: msg }]
@@ -671,6 +729,12 @@ window.loadClusters = async function() {
 
     if (clusters.length > 0) {
       showBanner(`Loaded ${clusters.length} cluster(s)`, "success");
+      const fu = document.getElementById("list-follow-ups");
+      fu.innerHTML = "";
+      renderFollowUps(fu, [
+        "Set up a cluster that is pending configuration",
+        "Create a new OpenShift cluster",
+      ]);
     } else {
       showBanner("No clusters found", "warning");
     }
@@ -721,10 +785,10 @@ function showDetail(cluster) {
   callTool("cluster_info", { cluster_id: cluster.id })
     .then(result => {
       const details = parseClusterDetail(result);
-      if (!details["Name"]) details["Name"] = cluster.name;
-      if (!details["ID"]) details["ID"] = cluster.id;
-      if (!details["Status"]) details["Status"] = cluster.status;
-      if (!details["Version"]) details["Version"] = cluster.openshift_version;
+      details["Name"] = cluster.name;
+      details["ID"] = cluster.id;
+      details["Status"] = cluster.status;
+      if (cluster.openshift_version) details["Version"] = cluster.openshift_version;
       renderDetailView(details, cluster.name);
       showDetailView();
       hideBanner();
@@ -775,6 +839,19 @@ function renderDetailView(details, title) {
   document.getElementById("load-events-btn").disabled = false;
   document.getElementById("logs-container").innerHTML = "";
   document.getElementById("load-logs-btn").disabled = false;
+
+  const fu = document.getElementById("detail-follow-ups");
+  fu.innerHTML = "";
+  const status = (details["Status"] || "").toLowerCase();
+  const prompts = [];
+  if (["pending-for-input", "insufficient", "ready"].includes(status)) {
+    prompts.push("Set up this cluster");
+  }
+  if (["installing"].includes(status)) {
+    prompts.push("Check the installation progress");
+  }
+  prompts.push("Show cluster events for troubleshooting");
+  renderFollowUps(fu, prompts);
 }
 
 function showDetailView() {
@@ -913,28 +990,61 @@ function formatTime(ts) {
   }
 }
 
+async function suggestFollowUp(promptText) {
+  if (window.openai?.sendFollowUpMessage) {
+    await window.openai.sendFollowUpMessage({ prompt: promptText });
+  } else if (window.mcpApp) {
+    await window.mcpApp.sendMessage({
+      role: "user",
+      content: [{ type: "text", text: promptText }]
+    });
+  }
+}
+
+function renderFollowUps(container, prompts) {
+  const div = document.createElement("div");
+  div.className = "follow-ups";
+  for (const prompt of prompts) {
+    const btn = document.createElement("button");
+    btn.textContent = prompt;
+    btn.onclick = () => suggestFollowUp(prompt);
+    div.appendChild(btn);
+  }
+  container.appendChild(div);
+}
+
 // MCP App initialization
-import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
+function applyTheme(mod, app) {
+  const applyDocTheme = mod.applyDocumentTheme || mod.default?.applyDocumentTheme;
+  const applyStyles = mod.applyHostStyleVariables || mod.default?.applyHostStyleVariables;
+  try {
+    const ctx = app.getHostContext?.();
+    if (ctx?.theme && applyDocTheme) applyDocTheme(ctx.theme);
+    if (ctx?.styles?.variables && applyStyles) applyStyles(ctx.styles.variables);
+  } catch {}
+  app.onhostcontextchanged = (ctx) => {
+    if (ctx.theme && applyDocTheme) applyDocTheme(ctx.theme);
+    if (ctx?.styles?.variables && applyStyles) applyStyles(ctx.styles.variables);
+  };
+}
+
+function initMcp(module) {
   const App = module.App || module.default?.App || module.default;
   const AppClass = App.App || App;
   const app = new AppClass({ name: "Cluster Inventory", version: "1.0.0" });
-  app.connect();
   window.mcpApp = app;
-  mcpReady = true;
-  loadClusters();
-}).catch(err => {
+  app.connect().then(() => {
+    applyTheme(module, app);
+    mcpReady = true;
+    loadClusters();
+  });
+}
+
+import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(initMcp).catch(err => {
   console.error("Failed to load MCP Apps SDK:", err);
   showBanner("Failed to connect to MCP. Retrying in 3s...", "error");
   setTimeout(() => {
-    import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
-      const App = module.App || module.default?.App || module.default;
-      const AppClass = App.App || App;
-      const app = new AppClass({ name: "Cluster Inventory", version: "1.0.0" });
-      app.connect();
-      window.mcpApp = app;
-      mcpReady = true;
-      loadClusters();
-    }).catch(err2 => {
+    import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(initMcp).catch(() => {
       showBanner("MCP connection failed. Please reload.", "error");
     });
   }, 3000);

--- a/assisted_service_mcp/src/tools/cluster_inventory.html
+++ b/assisted_service_mcp/src/tools/cluster_inventory.html
@@ -1,0 +1,945 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Cluster Inventory</title>
+<style>
+:root {
+  --font-family: var(--pf-v5-global--FontFamily--text, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif);
+  --color-primary: #06c;
+  --color-success: #3e8635;
+  --color-error: #c9190b;
+  --color-warning: #f0ab00;
+  --color-bg: #ffffff;
+  --color-bg-alt: #f5f5f5;
+  --color-border: #d2d2d2;
+  --color-text: #151515;
+  --color-text-secondary: #6a6e73;
+  --color-hover-row: #f0f0f0;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font-family);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--color-text);
+  background: var(--color-bg);
+  padding: 16px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.header h1 {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.header-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.banner {
+  padding: 10px 14px;
+  border-radius: 4px;
+  margin-bottom: 12px;
+  font-size: 13px;
+  display: none;
+}
+
+.banner.visible {
+  display: block;
+}
+
+.banner.loading {
+  background: #e7f1fa;
+  border: 1px solid var(--color-primary);
+  color: var(--color-primary);
+}
+
+.banner.success {
+  background: #e9f7e9;
+  border: 1px solid var(--color-success);
+  color: var(--color-success);
+}
+
+.banner.error {
+  background: #fce8e8;
+  border: 1px solid var(--color-error);
+  color: var(--color-error);
+}
+
+.banner.warning {
+  background: #fef6e0;
+  border: 1px solid var(--color-warning);
+  color: #795600;
+}
+
+.toolbar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.search-input {
+  flex: 1;
+  min-width: 200px;
+  padding: 6px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-size: 14px;
+  font-family: var(--font-family);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.search-input:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 1px var(--color-primary);
+}
+
+button {
+  padding: 6px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-bg);
+  font-size: 13px;
+  font-family: var(--font-family);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+button:hover {
+  background: var(--color-bg-alt);
+  border-color: #8a8d90;
+}
+
+button.primary {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+
+button.primary:hover {
+  background: #004d99;
+  border-color: #004d99;
+}
+
+button.success {
+  background: var(--color-success);
+  border-color: var(--color-success);
+  color: #fff;
+}
+
+button.success:hover {
+  background: #2e6b28;
+  border-color: #2e6b28;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.table-container {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+th {
+  background: var(--color-bg-alt);
+  font-weight: 600;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--color-text-secondary);
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+tr:hover td {
+  background: var(--color-hover-row);
+}
+
+.cluster-link {
+  color: var(--color-primary);
+  text-decoration: none;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.cluster-link:hover {
+  text-decoration: underline;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.status-ready, .status-installed, .status-adding-hosts {
+  background: #e9f7e9;
+  color: var(--color-success);
+}
+
+.status-error, .status-cancelled {
+  background: #fce8e8;
+  color: var(--color-error);
+}
+
+.status-pending-for-input, .status-insufficient {
+  background: #fef6e0;
+  color: #795600;
+}
+
+.status-installing, .status-preparing-for-installation, .status-finalizing {
+  background: #e7f1fa;
+  color: var(--color-primary);
+}
+
+.id-cell {
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.id-cell:hover {
+  max-width: none;
+  overflow: visible;
+}
+
+.detail-view {
+  display: none;
+}
+
+.detail-view.visible {
+  display: block;
+}
+
+.detail-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.detail-header h2 {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.detail-section {
+  margin-bottom: 20px;
+}
+
+.detail-section h3 {
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: minmax(160px, auto) 1fr;
+  gap: 6px 16px;
+}
+
+.detail-key {
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+.detail-value {
+  word-break: break-all;
+}
+
+.detail-actions {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.events-list {
+  list-style: none;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.events-list li {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 13px;
+}
+
+.events-list li:last-child {
+  border-bottom: none;
+}
+
+.event-time {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  margin-right: 8px;
+  font-family: monospace;
+}
+
+.event-severity-error {
+  border-left: 3px solid var(--color-error);
+}
+
+.event-severity-warning {
+  border-left: 3px solid var(--color-warning);
+}
+
+.event-severity-info {
+  border-left: 3px solid var(--color-primary);
+}
+
+.logs-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-primary);
+  text-decoration: none;
+  padding: 6px 12px;
+  border: 1px solid var(--color-primary);
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.logs-link:hover {
+  background: #e7f1fa;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--color-text-secondary);
+}
+
+.empty-state p {
+  margin-top: 8px;
+}
+
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.count-badge {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  margin-left: 8px;
+  font-weight: 400;
+}
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>Cluster Inventory</h1>
+  <div class="header-actions">
+    <button onclick="loadClusters()" id="refresh-btn">Refresh</button>
+  </div>
+</div>
+
+<div class="banner" id="banner"></div>
+
+<!-- List View -->
+<div id="list-view">
+  <div class="toolbar">
+    <input type="text" class="search-input" id="search-input"
+           placeholder="Search by name or ID..." oninput="filterClusters()">
+    <button class="primary" onclick="lookupCluster()" id="lookup-btn">Lookup by ID</button>
+  </div>
+
+  <div class="table-container" id="table-container">
+    <div class="empty-state" id="empty-state">
+      <p>Loading clusters...</p>
+    </div>
+    <table id="cluster-table" style="display:none">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Status</th>
+          <th>Version</th>
+          <th>ID</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody id="cluster-tbody"></tbody>
+    </table>
+  </div>
+</div>
+
+<!-- Detail View -->
+<div class="detail-view" id="detail-view">
+  <div class="detail-header">
+    <button onclick="showListView()">&#8592; Back</button>
+    <h2 id="detail-title">Cluster Detail</h2>
+  </div>
+
+  <div class="detail-actions" id="detail-actions"></div>
+
+  <div class="detail-section">
+    <h3>Cluster Information</h3>
+    <div class="detail-grid" id="detail-info"></div>
+  </div>
+
+  <div class="detail-section">
+    <h3>Events</h3>
+    <button onclick="loadEvents()" id="load-events-btn">Load Events</button>
+    <ul class="events-list" id="events-list" style="display:none; margin-top:8px"></ul>
+  </div>
+
+  <div class="detail-section">
+    <h3>Logs</h3>
+    <button onclick="loadLogs()" id="load-logs-btn">Download Logs</button>
+    <div id="logs-container" style="margin-top:8px"></div>
+  </div>
+</div>
+
+<script type="module">
+
+let clusters = [];
+let filteredClusters = [];
+let currentClusterId = null;
+let mcpReady = false;
+
+const SETUP_STATUSES = ["pending-for-input", "insufficient", "ready"];
+
+function showBanner(message, type = "loading") {
+  const banner = document.getElementById("banner");
+  banner.textContent = message;
+  banner.className = `banner visible ${type}`;
+  if (type === "success") {
+    setTimeout(() => { banner.classList.remove("visible"); }, 3000);
+  }
+}
+
+function hideBanner() {
+  document.getElementById("banner").classList.remove("visible");
+}
+
+async function callTool(name, args = {}) {
+  if (!window.mcpApp) {
+    throw new Error("MCP App not connected");
+  }
+  const result = await window.mcpApp.callServerTool({ name, arguments: args });
+  const text = result.content?.find(c => c.type === "text")?.text;
+  if (!text) return null;
+  try { return JSON.parse(text); } catch { return text; }
+}
+
+function parseClusterList(text) {
+  if (!text) return [];
+
+  if (typeof text === "object" && Array.isArray(text)) {
+    return text;
+  }
+
+  const lines = text.split("\n");
+  const parsed = [];
+
+  try {
+    for (const line of lines) {
+      if (line.trim()) {
+        const obj = JSON.parse(line.trim());
+        if (obj && obj.name) parsed.push(obj);
+      }
+    }
+    if (parsed.length > 0) return parsed;
+  } catch {}
+
+  let current = null;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      if (current && current.name) {
+        parsed.push(current);
+        current = null;
+      }
+      continue;
+    }
+
+    if (!trimmed.startsWith("-") && !trimmed.startsWith("*")) {
+      if (current && current.name) {
+        parsed.push(current);
+      }
+      current = { name: trimmed, id: "", openshift_version: "", status: "unknown" };
+    } else if (current) {
+      const cleaned = trimmed.replace(/^[-*]\s*/, "");
+      const idMatch = cleaned.match(/^ID:\s*(.+)/i);
+      const versionMatch = cleaned.match(/^(?:Openshift\s+)?[Vv]ersion:\s*(.+)/i);
+      const statusMatch = cleaned.match(/^Status:\s*(.+)/i);
+
+      if (idMatch) current.id = idMatch[1].trim();
+      else if (versionMatch) current.openshift_version = versionMatch[1].trim();
+      else if (statusMatch) current.status = statusMatch[1].trim();
+    }
+  }
+
+  if (current && current.name) {
+    parsed.push(current);
+  }
+
+  return parsed;
+}
+
+function parseClusterDetail(text) {
+  if (!text) return {};
+  if (typeof text === "object") return text;
+
+  const details = {};
+  const lines = text.split("\n");
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx > 0) {
+      let key = trimmed.substring(0, colonIdx).replace(/^[-*]\s*/, "").trim();
+      const value = trimmed.substring(colonIdx + 1).trim();
+      if (key && value) {
+        details[key] = value;
+      }
+    }
+  }
+
+  return details;
+}
+
+function getStatusClass(status) {
+  const normalized = (status || "unknown").toLowerCase().replace(/\s+/g, "-");
+  return `status-${normalized}`;
+}
+
+function truncateId(id) {
+  if (!id) return "";
+  return id.length > 12 ? id.substring(0, 8) + "..." : id;
+}
+
+function renderTable() {
+  const tbody = document.getElementById("cluster-tbody");
+  const table = document.getElementById("cluster-table");
+  const emptyState = document.getElementById("empty-state");
+
+  if (filteredClusters.length === 0) {
+    table.style.display = "none";
+    emptyState.innerHTML = clusters.length === 0
+      ? "<p>No clusters found.</p>"
+      : "<p>No clusters match your search.</p>";
+    emptyState.style.display = "block";
+    return;
+  }
+
+  emptyState.style.display = "none";
+  table.style.display = "table";
+  tbody.innerHTML = "";
+
+  for (const cluster of filteredClusters) {
+    const tr = document.createElement("tr");
+
+    const nameTd = document.createElement("td");
+    const nameLink = document.createElement("a");
+    nameLink.className = "cluster-link";
+    nameLink.textContent = cluster.name || "(unnamed)";
+    nameLink.onclick = () => showDetail(cluster);
+    nameTd.appendChild(nameLink);
+
+    const statusTd = document.createElement("td");
+    const badge = document.createElement("span");
+    badge.className = `status-badge ${getStatusClass(cluster.status)}`;
+    badge.textContent = cluster.status || "unknown";
+    statusTd.appendChild(badge);
+
+    const versionTd = document.createElement("td");
+    versionTd.textContent = cluster.openshift_version || "-";
+
+    const idTd = document.createElement("td");
+    idTd.className = "id-cell";
+    idTd.textContent = cluster.id || "-";
+    idTd.title = cluster.id || "";
+
+    const actionsTd = document.createElement("td");
+    if (SETUP_STATUSES.includes((cluster.status || "").toLowerCase())) {
+      const setupBtn = document.createElement("button");
+      setupBtn.className = "success";
+      setupBtn.textContent = "Setup";
+      setupBtn.onclick = (e) => {
+        e.stopPropagation();
+        sendSetupMessage(cluster);
+      };
+      actionsTd.appendChild(setupBtn);
+    }
+
+    tr.appendChild(nameTd);
+    tr.appendChild(statusTd);
+    tr.appendChild(versionTd);
+    tr.appendChild(idTd);
+    tr.appendChild(actionsTd);
+    tbody.appendChild(tr);
+  }
+}
+
+function sendSetupMessage(cluster) {
+  if (!window.mcpApp) return;
+  const msg = `Set up cluster ${cluster.name} (ID: ${cluster.id})`;
+  window.mcpApp.sendMessage({
+    role: "user",
+    content: [{ type: "text", text: msg }]
+  });
+  showBanner(`Setup request sent for "${cluster.name}"`, "success");
+}
+
+window.filterClusters = function() {
+  const query = document.getElementById("search-input").value.toLowerCase().trim();
+  if (!query) {
+    filteredClusters = [...clusters];
+  } else {
+    filteredClusters = clusters.filter(c =>
+      (c.name || "").toLowerCase().includes(query) ||
+      (c.id || "").toLowerCase().includes(query)
+    );
+  }
+  renderTable();
+};
+
+window.loadClusters = async function() {
+  showBanner("Loading clusters...", "loading");
+  document.getElementById("refresh-btn").disabled = true;
+
+  try {
+    const result = await callTool("list_clusters");
+    clusters = parseClusterList(result);
+    filteredClusters = [...clusters];
+    renderTable();
+
+    if (clusters.length > 0) {
+      showBanner(`Loaded ${clusters.length} cluster(s)`, "success");
+    } else {
+      showBanner("No clusters found", "warning");
+    }
+  } catch (err) {
+    showBanner(`Failed to load clusters: ${err.message}`, "error");
+    document.getElementById("empty-state").innerHTML =
+      `<p>Error loading clusters. Check connection and try again.</p>`;
+    document.getElementById("empty-state").style.display = "block";
+    document.getElementById("cluster-table").style.display = "none";
+  } finally {
+    document.getElementById("refresh-btn").disabled = false;
+  }
+};
+
+window.lookupCluster = async function() {
+  const query = document.getElementById("search-input").value.trim();
+  if (!query) {
+    showBanner("Enter a cluster ID in the search box first", "warning");
+    return;
+  }
+
+  showBanner(`Looking up cluster "${query}"...`, "loading");
+  document.getElementById("lookup-btn").disabled = true;
+
+  try {
+    const result = await callTool("cluster_info", { cluster_id: query });
+    if (!result) {
+      showBanner("No data returned for that cluster ID", "warning");
+      return;
+    }
+
+    const details = parseClusterDetail(result);
+    currentClusterId = query;
+    renderDetailView(details, query);
+    showDetailView();
+    hideBanner();
+  } catch (err) {
+    showBanner(`Lookup failed: ${err.message}`, "error");
+  } finally {
+    document.getElementById("lookup-btn").disabled = false;
+  }
+};
+
+function showDetail(cluster) {
+  currentClusterId = cluster.id;
+  showBanner(`Loading details for "${cluster.name}"...`, "loading");
+
+  callTool("cluster_info", { cluster_id: cluster.id })
+    .then(result => {
+      const details = parseClusterDetail(result);
+      if (!details["Name"]) details["Name"] = cluster.name;
+      if (!details["ID"]) details["ID"] = cluster.id;
+      if (!details["Status"]) details["Status"] = cluster.status;
+      if (!details["Version"]) details["Version"] = cluster.openshift_version;
+      renderDetailView(details, cluster.name);
+      showDetailView();
+      hideBanner();
+    })
+    .catch(err => {
+      showBanner(`Failed to load details: ${err.message}`, "error");
+    });
+}
+
+function renderDetailView(details, title) {
+  document.getElementById("detail-title").textContent = title || "Cluster Detail";
+
+  const infoGrid = document.getElementById("detail-info");
+  infoGrid.innerHTML = "";
+
+  for (const [key, value] of Object.entries(details)) {
+    const keyEl = document.createElement("span");
+    keyEl.className = "detail-key";
+    keyEl.textContent = key;
+
+    const valueEl = document.createElement("span");
+    valueEl.className = "detail-value";
+    valueEl.textContent = value;
+
+    infoGrid.appendChild(keyEl);
+    infoGrid.appendChild(valueEl);
+  }
+
+  const actionsDiv = document.getElementById("detail-actions");
+  actionsDiv.innerHTML = "";
+
+  const status = (details["Status"] || "").toLowerCase();
+  if (SETUP_STATUSES.includes(status)) {
+    const setupBtn = document.createElement("button");
+    setupBtn.className = "success";
+    setupBtn.textContent = "Setup Cluster";
+    setupBtn.onclick = () => {
+      sendSetupMessage({
+        name: details["Name"] || title,
+        id: currentClusterId
+      });
+    };
+    actionsDiv.appendChild(setupBtn);
+  }
+
+  document.getElementById("events-list").style.display = "none";
+  document.getElementById("events-list").innerHTML = "";
+  document.getElementById("load-events-btn").disabled = false;
+  document.getElementById("logs-container").innerHTML = "";
+  document.getElementById("load-logs-btn").disabled = false;
+}
+
+function showDetailView() {
+  document.getElementById("list-view").style.display = "none";
+  document.getElementById("detail-view").classList.add("visible");
+}
+
+window.showListView = function() {
+  document.getElementById("detail-view").classList.remove("visible");
+  document.getElementById("list-view").style.display = "block";
+  currentClusterId = null;
+};
+
+window.loadEvents = async function() {
+  if (!currentClusterId) return;
+
+  const btn = document.getElementById("load-events-btn");
+  btn.disabled = true;
+  btn.textContent = "Loading...";
+
+  try {
+    const result = await callTool("cluster_events", { cluster_id: currentClusterId });
+    const eventsList = document.getElementById("events-list");
+    eventsList.innerHTML = "";
+
+    let events = [];
+    if (Array.isArray(result)) {
+      events = result;
+    } else if (typeof result === "string") {
+      try {
+        events = JSON.parse(result);
+      } catch {
+        eventsList.innerHTML = `<li>${result}</li>`;
+        eventsList.style.display = "block";
+        btn.textContent = "Reload Events";
+        btn.disabled = false;
+        return;
+      }
+    }
+
+    if (!events || events.length === 0) {
+      eventsList.innerHTML = "<li>No events found.</li>";
+    } else {
+      for (const event of events) {
+        const li = document.createElement("li");
+        const severity = (event.severity || event.level || "info").toLowerCase();
+        li.className = `event-severity-${severity}`;
+
+        const time = event.event_time || event.timestamp || event.time || "";
+        if (time) {
+          const timeSpan = document.createElement("span");
+          timeSpan.className = "event-time";
+          timeSpan.textContent = formatTime(time);
+          li.appendChild(timeSpan);
+        }
+
+        const msg = document.createTextNode(event.message || event.msg || JSON.stringify(event));
+        li.appendChild(msg);
+        eventsList.appendChild(li);
+      }
+    }
+
+    eventsList.style.display = "block";
+    btn.textContent = "Reload Events";
+  } catch (err) {
+    showBanner(`Failed to load events: ${err.message}`, "error");
+    btn.textContent = "Retry Events";
+  } finally {
+    btn.disabled = false;
+  }
+};
+
+window.loadLogs = async function() {
+  if (!currentClusterId) return;
+
+  const btn = document.getElementById("load-logs-btn");
+  btn.disabled = true;
+  btn.textContent = "Fetching URL...";
+
+  try {
+    const result = await callTool("cluster_logs_download_url", { cluster_id: currentClusterId });
+    const container = document.getElementById("logs-container");
+    container.innerHTML = "";
+
+    let url = null;
+    if (typeof result === "object" && result !== null) {
+      url = result.url || result.download_url || result.logs_url;
+    } else if (typeof result === "string") {
+      if (result.startsWith("http")) {
+        url = result;
+      } else {
+        try {
+          const parsed = JSON.parse(result);
+          url = parsed.url || parsed.download_url || parsed.logs_url;
+        } catch {
+          url = result;
+        }
+      }
+    }
+
+    if (url) {
+      const link = document.createElement("a");
+      link.className = "logs-link";
+      link.href = url;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.textContent = "Download Cluster Logs";
+      container.appendChild(link);
+    } else {
+      container.textContent = "No download URL available.";
+    }
+
+    btn.textContent = "Refresh Logs URL";
+  } catch (err) {
+    showBanner(`Failed to get logs URL: ${err.message}`, "error");
+    btn.textContent = "Retry";
+  } finally {
+    btn.disabled = false;
+  }
+};
+
+function formatTime(ts) {
+  if (!ts) return "";
+  try {
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return ts;
+    return d.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit"
+    });
+  } catch {
+    return ts;
+  }
+}
+
+// MCP App initialization
+import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
+  const App = module.App || module.default?.App || module.default;
+  const AppClass = App.App || App;
+  const app = new AppClass({ name: "Cluster Inventory", version: "1.0.0" });
+  app.connect();
+  window.mcpApp = app;
+  mcpReady = true;
+  loadClusters();
+}).catch(err => {
+  console.error("Failed to load MCP Apps SDK:", err);
+  showBanner("Failed to connect to MCP. Retrying in 3s...", "error");
+  setTimeout(() => {
+    import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
+      const App = module.App || module.default?.App || module.default;
+      const AppClass = App.App || App;
+      const app = new AppClass({ name: "Cluster Inventory", version: "1.0.0" });
+      app.connect();
+      window.mcpApp = app;
+      mcpReady = true;
+      loadClusters();
+    }).catch(err2 => {
+      showBanner("MCP connection failed. Please reload.", "error");
+    });
+  }, 3000);
+});
+
+</script>
+</body>
+</html>

--- a/assisted_service_mcp/src/tools/cluster_inventory.html
+++ b/assisted_service_mcp/src/tools/cluster_inventory.html
@@ -521,19 +521,12 @@ function hideBanner() {
   document.getElementById("banner").classList.remove("visible");
 }
 
-function stripFollowUps(raw) {
-  if (!raw) return raw;
-  const idx = raw.indexOf("\n\n[IMPORTANT");
-  return idx !== -1 ? raw.substring(0, idx) : raw;
-}
-
 async function callTool(name, args = {}) {
   if (!window.mcpApp) {
     throw new Error("MCP App not connected");
   }
   const result = await window.mcpApp.callServerTool({ name, arguments: args });
-  const raw = result.content?.find(c => c.type === "text")?.text;
-  const text = stripFollowUps(raw);
+  const text = result.content?.find(c => c.type === "text")?.text;
   if (!text) return null;
   try { return JSON.parse(text); } catch { return text; }
 }

--- a/assisted_service_mcp/src/tools/cluster_inventory.html
+++ b/assisted_service_mcp/src/tools/cluster_inventory.html
@@ -521,12 +521,18 @@ function hideBanner() {
   document.getElementById("banner").classList.remove("visible");
 }
 
+function stripFollowUps(raw) {
+  if (!raw) return raw;
+  const idx = raw.indexOf("\n\n[IMPORTANT");
+  return idx !== -1 ? raw.substring(0, idx) : raw;
+}
+
 async function callTool(name, args = {}) {
   if (!window.mcpApp) {
     throw new Error("MCP App not connected");
   }
   const result = await window.mcpApp.callServerTool({ name, arguments: args });
-  const text = result.content?.find(c => c.type === "text")?.text;
+  const text = stripFollowUps(result.content?.find(c => c.type === "text")?.text);
   if (!text) return null;
   try { return JSON.parse(text); } catch { return text; }
 }

--- a/assisted_service_mcp/src/tools/cluster_inventory.html
+++ b/assisted_service_mcp/src/tools/cluster_inventory.html
@@ -521,12 +521,19 @@ function hideBanner() {
   document.getElementById("banner").classList.remove("visible");
 }
 
+function stripFollowUps(raw) {
+  if (!raw) return raw;
+  const idx = raw.indexOf("\n\n[IMPORTANT");
+  return idx !== -1 ? raw.substring(0, idx) : raw;
+}
+
 async function callTool(name, args = {}) {
   if (!window.mcpApp) {
     throw new Error("MCP App not connected");
   }
   const result = await window.mcpApp.callServerTool({ name, arguments: args });
-  const text = result.content?.find(c => c.type === "text")?.text;
+  const raw = result.content?.find(c => c.type === "text")?.text;
+  const text = stripFollowUps(raw);
   if (!text) return null;
   try { return JSON.parse(text); } catch { return text; }
 }

--- a/assisted_service_mcp/src/tools/cluster_setup.html
+++ b/assisted_service_mcp/src/tools/cluster_setup.html
@@ -1,0 +1,798 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OCP Admin — Cluster Setup</title>
+  <style>
+    :root {
+      --font-body: "Red Hat Text", "Noto Sans", "Segoe UI", sans-serif;
+      --font-heading: "Red Hat Display", "Noto Sans", "Segoe UI", sans-serif;
+      --sp-2xs: 0.25rem;
+      --sp-xs: 0.5rem;
+      --sp-sm: 0.75rem;
+      --sp-md: 1rem;
+      --sp-lg: 1.5rem;
+      --sp-xl: 2rem;
+      --bg-shell: #f8f8f8;
+      --bg-surface: #ffffff;
+      --text-primary: #151515;
+      --text-muted: #4f5255;
+      --border: #d2d2d2;
+      --color-primary: #06c;
+      --color-success: #3e8635;
+      --color-error: #c9190b;
+      --color-warning: #f0ab00;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--bg-shell);
+      color: var(--text-primary);
+      font-family: var(--font-body);
+      font-size: 14px;
+      line-height: 1.5;
+    }
+
+    #app {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: var(--sp-lg);
+    }
+
+    h1 {
+      margin: 0 0 var(--sp-xs);
+      font-family: var(--font-heading);
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+
+    h2 {
+      margin: 0 0 var(--sp-sm);
+      font-family: var(--font-heading);
+      font-size: 1.05rem;
+      font-weight: 600;
+    }
+
+    .subtitle {
+      margin: 0 0 var(--sp-lg);
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+
+    /* Status banner */
+    .banner {
+      border-left: 3px solid var(--color-primary);
+      background: #f0f8ff;
+      border-radius: 0.25rem;
+      padding: var(--sp-sm) var(--sp-md);
+      margin-bottom: var(--sp-md);
+      font-size: 0.9rem;
+    }
+    .banner--success { border-left-color: var(--color-success); background: #edf8ef; }
+    .banner--error   { border-left-color: var(--color-error);   background: #faeae8; }
+    .banner--warning { border-left-color: var(--color-warning); background: #fff8e7; }
+    .banner[hidden] { display: none; }
+
+    /* Card sections */
+    .card {
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: 0.375rem;
+      box-shadow: 0 1px 2px rgba(21,21,21,0.08);
+      padding: var(--sp-lg);
+      margin-bottom: var(--sp-md);
+    }
+
+    /* Empty / placeholder state */
+    .empty-state {
+      text-align: center;
+      padding: var(--sp-xl) var(--sp-lg);
+    }
+    .empty-state h2 { font-size: 1.1rem; color: var(--text-primary); }
+    .empty-state p  { color: var(--text-muted); margin: var(--sp-xs) 0 0; }
+
+    /* Cluster ID display */
+    .cluster-id {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.82rem;
+      background: #f3f3f3;
+      padding: 0.15rem 0.4rem;
+      border-radius: 0.2rem;
+      word-break: break-all;
+    }
+
+    /* Discovery ISO */
+    .iso-link {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--sp-xs);
+      color: var(--color-primary);
+      text-decoration: none;
+      font-weight: 500;
+    }
+    .iso-link:hover { text-decoration: underline; }
+    .iso-link::before { content: "\2B07"; font-size: 1.1em; }
+
+    /* Table */
+    .tbl-wrap { overflow-x: auto; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+    }
+    th, td {
+      border: 1px solid var(--border);
+      text-align: left;
+      padding: 0.45rem 0.55rem;
+    }
+    thead th {
+      background: #f3f3f3;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+    td.mono {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.8rem;
+    }
+
+    .role-select {
+      font: inherit;
+      font-size: 0.85rem;
+      padding: 0.25rem 0.4rem;
+      border: 1px solid var(--border);
+      border-radius: 0.25rem;
+      background: #fff;
+      cursor: pointer;
+    }
+
+    .badge {
+      display: inline-block;
+      font-size: 0.78rem;
+      padding: 0.1rem 0.45rem;
+      border-radius: 999px;
+      font-weight: 500;
+    }
+    .badge--assigned { background: #edf8ef; color: var(--color-success); }
+    .badge--pending  { background: #fff8e7; color: #8a6d00; }
+
+    /* Form elements */
+    .form-row {
+      display: flex;
+      gap: var(--sp-sm);
+      align-items: flex-end;
+      flex-wrap: wrap;
+    }
+    .form-group {
+      display: flex;
+      flex-direction: column;
+      gap: var(--sp-2xs);
+      flex: 1;
+      min-width: 160px;
+    }
+    .form-group label {
+      font-weight: 600;
+      font-size: 0.9rem;
+    }
+    .input {
+      border: 1px solid var(--border);
+      border-radius: 0.25rem;
+      padding: 0.5rem 0.65rem;
+      font: inherit;
+      color: var(--text-primary);
+      background: #fff;
+    }
+    .input:focus {
+      outline: 2px solid var(--color-primary);
+      outline-offset: -1px;
+    }
+
+    /* Buttons */
+    .btn {
+      font-family: var(--font-body);
+      font-size: 0.9rem;
+      border-radius: 0.25rem;
+      border: 1px solid transparent;
+      padding: 0.4rem 0.85rem;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: opacity 0.15s;
+    }
+    .btn:disabled { cursor: not-allowed; opacity: 0.55; }
+
+    .btn--primary {
+      color: #fff;
+      background: var(--color-primary);
+    }
+    .btn--primary:hover:not(:disabled) { background: #004d99; }
+
+    .btn--secondary {
+      color: var(--text-primary);
+      background: var(--bg-surface);
+      border-color: var(--border);
+    }
+    .btn--secondary:hover:not(:disabled) { background: #f3f3f3; }
+
+    .btn--danger {
+      color: #fff;
+      background: var(--color-error);
+    }
+    .btn--danger:hover:not(:disabled) { background: #a11509; }
+
+    .btn--ghost {
+      color: var(--color-primary);
+      background: transparent;
+      border-color: transparent;
+      padding-left: 0;
+      padding-right: 0;
+    }
+    .btn--ghost:hover:not(:disabled) { text-decoration: underline; }
+
+    .btn-row {
+      display: flex;
+      gap: var(--sp-sm);
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    /* Progress bar */
+    .progress-track {
+      width: 100%;
+      height: 6px;
+      background: #e0e0e0;
+      border-radius: 3px;
+      overflow: hidden;
+      margin: var(--sp-sm) 0;
+    }
+    .progress-fill {
+      height: 100%;
+      background: var(--color-primary);
+      border-radius: 3px;
+      transition: width 0.4s ease;
+    }
+    .progress-label {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+    }
+
+    /* Readiness summary */
+    .readiness {
+      font-size: 0.9rem;
+      color: var(--text-muted);
+      margin-bottom: var(--sp-sm);
+    }
+    .readiness strong { color: var(--text-primary); }
+
+    /* Confirmation dialog overlay */
+    .confirm-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(21,21,21,0.45);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+    }
+    .confirm-dialog {
+      background: var(--bg-surface);
+      border-radius: 0.5rem;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.18);
+      padding: var(--sp-lg);
+      max-width: 420px;
+      width: 90%;
+    }
+    .confirm-dialog h2 { margin-bottom: var(--sp-sm); }
+    .confirm-dialog p {
+      margin: 0 0 var(--sp-lg);
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .confirm-dialog .btn-row { justify-content: flex-end; }
+
+    /* Installed banner */
+    .success-banner {
+      background: #edf8ef;
+      border: 1px solid var(--color-success);
+      border-radius: 0.375rem;
+      padding: var(--sp-md) var(--sp-lg);
+      text-align: center;
+      color: var(--color-success);
+      font-weight: 600;
+      font-size: 1rem;
+    }
+    .error-banner {
+      background: #faeae8;
+      border: 1px solid var(--color-error);
+      border-radius: 0.375rem;
+      padding: var(--sp-md) var(--sp-lg);
+      text-align: center;
+      color: var(--color-error);
+      font-weight: 600;
+      font-size: 1rem;
+    }
+
+    /* Spacing helpers */
+    .mt-sm  { margin-top: var(--sp-sm); }
+    .mt-md  { margin-top: var(--sp-md); }
+    .mb-sm  { margin-bottom: var(--sp-sm); }
+    .muted  { color: var(--text-muted); }
+    .small  { font-size: 0.85rem; }
+
+    .spinner::after {
+      content: "";
+      display: inline-block;
+      width: 14px;
+      height: 14px;
+      border: 2px solid var(--border);
+      border-top-color: var(--color-primary);
+      border-radius: 50%;
+      animation: spin 0.6s linear infinite;
+      vertical-align: middle;
+      margin-left: var(--sp-xs);
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+
+  <script type="module">
+    const state = {
+      clusterId: null,
+      hosts: [],
+      isLoadingHosts: false,
+      discoveryIsoUrl: null,
+      apiVip: "",
+      ingressVip: "",
+      installationStatus: null,
+      installationProgress: 0,
+      installationStatusInfo: null,
+      isStartingInstallation: false,
+      showInstallConfirm: false,
+      statusMessage: "",
+      statusVariant: "info",
+    };
+
+    const root = document.getElementById("app");
+
+    function esc(str) {
+      const d = document.createElement("div");
+      d.textContent = str ?? "";
+      return d.innerHTML;
+    }
+
+    /* ---------- MCP SDK ---------- */
+    import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
+      const App = module.App || module.default?.App || module.default;
+      const app = new (App.App || App)({ name: "Cluster Setup", version: "1.0.0" });
+      app.connect();
+      window.mcpApp = app;
+
+      app.ontoolinput = (params) => {
+        const args = params.arguments;
+        if (args?.cluster_id && typeof args.cluster_id === "string") {
+          state.clusterId = args.cluster_id;
+          render();
+          loadHosts();
+        }
+      };
+      app.ontoolresult = (params) => {
+        const sc = params.structuredContent;
+        if (sc?.cluster_id && typeof sc.cluster_id === "string" && !state.clusterId) {
+          state.clusterId = sc.cluster_id;
+          render();
+          loadHosts();
+        }
+      };
+    }).catch(() => {});
+
+    async function callTool(name, args = {}) {
+      if (!window.mcpApp) return null;
+      try {
+        const result = await window.mcpApp.callServerTool({ name, arguments: args });
+        const text = result.content?.find(c => c.type === "text")?.text;
+        if (!text) return null;
+        try { return JSON.parse(text); } catch { return text; }
+      } catch (err) {
+        setStatus("Tool call failed: " + (err?.message || err), "error");
+        render();
+        return null;
+      }
+    }
+
+    /* ---------- Status helpers ---------- */
+    function setStatus(msg, variant) {
+      state.statusMessage = msg;
+      state.statusVariant = variant || "info";
+    }
+
+    /* ---------- Actions ---------- */
+    async function loadHosts() {
+      if (!state.clusterId) return;
+      state.isLoadingHosts = true;
+      state.hosts = [];
+      setStatus("Loading hosts\u2026", "info");
+      render();
+
+      const data = await callTool("get_cluster_hosts", { cluster_id: state.clusterId });
+      state.isLoadingHosts = false;
+
+      if (!data || typeof data !== "object") {
+        setStatus("Failed to load hosts.", "error");
+        render();
+        return;
+      }
+
+      state.hosts = Array.isArray(data.hosts) ? data.hosts : [];
+      state.discoveryIsoUrl = data.discovery_iso_url || null;
+      setStatus("Loaded " + state.hosts.length + " host(s).", "success");
+      render();
+    }
+
+    async function setHostRole(hostId, role) {
+      if (!state.clusterId) return;
+      setStatus("Setting role\u2026", "info");
+      render();
+
+      const data = await callTool("set_host_role", {
+        host_id: hostId,
+        cluster_id: state.clusterId,
+        role,
+      });
+
+      if (data === null) {
+        setStatus("Failed to set host role.", "error");
+        render();
+        return;
+      }
+
+      state.hosts = state.hosts.map(h =>
+        h.id === hostId ? { ...h, role } : h
+      );
+      setStatus("Host role set to " + role + ".", "success");
+      render();
+    }
+
+    async function setVips() {
+      if (!state.clusterId) return;
+      if (!state.apiVip.trim() || !state.ingressVip.trim()) {
+        setStatus("Both API VIP and Ingress VIP are required.", "warning");
+        render();
+        return;
+      }
+
+      setStatus("Setting VIPs\u2026", "info");
+      render();
+
+      const data = await callTool("set_cluster_vips", {
+        cluster_id: state.clusterId,
+        api_vip: state.apiVip.trim(),
+        ingress_vip: state.ingressVip.trim(),
+      });
+
+      if (data === null) {
+        setStatus("Failed to set VIPs.", "error");
+        render();
+        return;
+      }
+
+      setStatus("VIPs configured. API: " + state.apiVip + ", Ingress: " + state.ingressVip + ".", "success");
+      render();
+    }
+
+    async function startInstallation() {
+      if (!state.clusterId) return;
+      state.showInstallConfirm = false;
+      state.isStartingInstallation = true;
+      setStatus("Starting installation\u2026", "info");
+      render();
+
+      const data = await callTool("install_cluster", { cluster_id: state.clusterId });
+      state.isStartingInstallation = false;
+
+      if (data === null) {
+        setStatus("Failed to start installation.", "error");
+        render();
+        return;
+      }
+
+      state.installationStatus = "installing";
+      state.installationProgress = 0;
+      setStatus("Installation started.", "success");
+      render();
+    }
+
+    async function refreshProgress() {
+      if (!state.clusterId) return;
+      setStatus("Refreshing progress\u2026", "info");
+      render();
+
+      const data = await callTool("get_installation_progress", { cluster_id: state.clusterId });
+
+      if (!data || typeof data !== "object") {
+        setStatus("Failed to get installation progress.", "warning");
+        render();
+        return;
+      }
+
+      state.installationStatus = data.status || "unknown";
+      state.installationProgress = typeof data.progress === "number" ? data.progress : 0;
+      state.installationStatusInfo = data.status_info || null;
+
+      if (state.installationStatus === "installed") {
+        setStatus("Installation complete!", "success");
+      } else if (state.installationStatus === "error") {
+        setStatus("Installation failed.", "error");
+      } else {
+        setStatus("Installing\u2026 " + state.installationProgress + "%", "info");
+      }
+      render();
+    }
+
+    /* ---------- Readiness checks ---------- */
+    function hostsWithRoles() {
+      return state.hosts.filter(h => h.role && h.role !== "auto-assign");
+    }
+    function vipsConfigured() {
+      return state.apiVip.trim() !== "" && state.ingressVip.trim() !== "";
+    }
+    function canInstall() {
+      return state.hosts.length > 0
+        && hostsWithRoles().length === state.hosts.length
+        && vipsConfigured()
+        && !state.isStartingInstallation
+        && state.installationStatus !== "installing"
+        && state.installationStatus !== "installed";
+    }
+
+    /* ---------- Event delegation ---------- */
+    root.addEventListener("click", (e) => {
+      const btn = e.target.closest("[data-action]");
+      if (!btn) return;
+      const action = btn.dataset.action;
+      if (action === "load-hosts")       loadHosts();
+      if (action === "set-vips")         setVips();
+      if (action === "show-confirm")     { state.showInstallConfirm = true; render(); }
+      if (action === "cancel-confirm")   { state.showInstallConfirm = false; render(); }
+      if (action === "confirm-install")  startInstallation();
+      if (action === "refresh-progress") refreshProgress();
+    });
+
+    root.addEventListener("change", (e) => {
+      if (e.target.matches(".role-select")) {
+        setHostRole(e.target.dataset.hostId, e.target.value);
+      }
+    });
+
+    root.addEventListener("input", (e) => {
+      if (e.target.id === "api-vip")     state.apiVip = e.target.value;
+      if (e.target.id === "ingress-vip") state.ingressVip = e.target.value;
+    });
+
+    /* ---------- Render ---------- */
+    function render() {
+      if (!state.clusterId) {
+        root.innerHTML = renderEmpty();
+        return;
+      }
+      root.innerHTML = renderDashboard();
+    }
+
+    function renderEmpty() {
+      return `
+        <div class="card empty-state">
+          <h2>No cluster selected for setup</h2>
+          <p>Use a tool that provides a <code>cluster_id</code> to get started,
+             or ask the assistant to set up a specific cluster.</p>
+        </div>`;
+    }
+
+    function renderBanner() {
+      if (!state.statusMessage) return "";
+      const cls = state.statusVariant === "success" ? "banner--success"
+                : state.statusVariant === "error"   ? "banner--error"
+                : state.statusVariant === "warning" ? "banner--warning"
+                : "";
+      return `<div class="banner ${cls}">${esc(state.statusMessage)}</div>`;
+    }
+
+    function renderDashboard() {
+      return `
+        <h1>Cluster Setup</h1>
+        <p class="subtitle">Setting up cluster <span class="cluster-id">${esc(state.clusterId)}</span></p>
+        ${renderBanner()}
+        ${renderDiscoveryIso()}
+        ${renderHostsSection()}
+        ${renderVipsSection()}
+        ${renderInstallSection()}
+        ${state.showInstallConfirm ? renderConfirmDialog() : ""}`;
+    }
+
+    function renderDiscoveryIso() {
+      if (!state.discoveryIsoUrl) return "";
+      return `
+        <div class="card">
+          <h2>Discovery ISO</h2>
+          <a class="iso-link" href="${esc(state.discoveryIsoUrl)}" target="_blank" rel="noopener">
+            Download Discovery ISO
+          </a>
+          <p class="small muted mt-sm">Boot hosts with this ISO to register them for the cluster.</p>
+        </div>`;
+    }
+
+    function renderHostsSection() {
+      let body;
+      if (state.isLoadingHosts) {
+        body = `<p class="muted">Loading hosts<span class="spinner"></span></p>`;
+      } else if (state.hosts.length === 0) {
+        body = `<p class="muted">No hosts loaded yet. Click <strong>Load Hosts</strong> to fetch registered hosts.</p>`;
+      } else {
+        body = `
+          <div class="tbl-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Hostname</th>
+                  <th>Status</th>
+                  <th>Role</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${state.hosts.map(renderHostRow).join("")}
+              </tbody>
+            </table>
+          </div>`;
+      }
+
+      return `
+        <div class="card">
+          <h2>Hosts</h2>
+          ${body}
+          <div class="btn-row mt-md">
+            <button class="btn btn--secondary" data-action="load-hosts"
+              ${state.isLoadingHosts ? "disabled" : ""}>
+              ${state.isLoadingHosts ? "Loading\u2026" : state.hosts.length ? "Refresh Hosts" : "Load Hosts"}
+            </button>
+          </div>
+        </div>`;
+    }
+
+    function renderHostRow(host) {
+      const roles = ["auto-assign", "master", "worker"];
+      const currentRole = host.role || "auto-assign";
+      const isAssigned = currentRole !== "auto-assign";
+
+      const options = roles.map(r =>
+        `<option value="${r}" ${r === currentRole ? "selected" : ""}>${r}</option>`
+      ).join("");
+
+      return `
+        <tr>
+          <td class="mono">${esc(host.hostname || host.id)}</td>
+          <td>${esc(host.status || "unknown")}</td>
+          <td>
+            <select class="role-select" data-host-id="${esc(host.id)}">
+              ${options}
+            </select>
+          </td>
+          <td>
+            <span class="badge ${isAssigned ? "badge--assigned" : "badge--pending"}">
+              ${isAssigned ? "Assigned" : "Pending"}
+            </span>
+          </td>
+        </tr>`;
+    }
+
+    function renderVipsSection() {
+      return `
+        <div class="card">
+          <h2>Virtual IPs (VIPs)</h2>
+          <div class="form-row">
+            <div class="form-group">
+              <label for="api-vip">API VIP</label>
+              <input class="input" type="text" id="api-vip"
+                placeholder="e.g. 192.168.1.100"
+                value="${esc(state.apiVip)}" />
+            </div>
+            <div class="form-group">
+              <label for="ingress-vip">Ingress VIP</label>
+              <input class="input" type="text" id="ingress-vip"
+                placeholder="e.g. 192.168.1.101"
+                value="${esc(state.ingressVip)}" />
+            </div>
+          </div>
+          <div class="btn-row mt-md">
+            <button class="btn btn--primary" data-action="set-vips"
+              ${(!state.apiVip.trim() || !state.ingressVip.trim()) ? "disabled" : ""}>
+              Set VIPs
+            </button>
+          </div>
+        </div>`;
+    }
+
+    function renderInstallSection() {
+      const assigned = hostsWithRoles().length;
+      const total = state.hosts.length;
+      const vipsOk = vipsConfigured();
+
+      if (state.installationStatus === "installed") {
+        return `
+          <div class="card">
+            <h2>Installation</h2>
+            <div class="success-banner">OpenShift cluster installed successfully</div>
+            ${state.installationStatusInfo
+              ? `<p class="small muted mt-sm">${esc(state.installationStatusInfo)}</p>` : ""}
+          </div>`;
+      }
+
+      if (state.installationStatus === "error") {
+        return `
+          <div class="card">
+            <h2>Installation</h2>
+            <div class="error-banner">Installation failed</div>
+            ${state.installationStatusInfo
+              ? `<p class="small muted mt-sm">${esc(state.installationStatusInfo)}</p>` : ""}
+            <div class="btn-row mt-md">
+              <button class="btn btn--secondary" data-action="refresh-progress">Refresh Progress</button>
+            </div>
+          </div>`;
+      }
+
+      if (state.installationStatus === "installing" || state.isStartingInstallation) {
+        return `
+          <div class="card">
+            <h2>Installation</h2>
+            <div class="progress-track">
+              <div class="progress-fill" style="width:${state.installationProgress}%"></div>
+            </div>
+            <p class="progress-label">
+              ${state.installationProgress}% complete
+              ${state.installationStatusInfo ? " \u2014 " + esc(state.installationStatusInfo) : ""}
+            </p>
+            <div class="btn-row mt-sm">
+              <button class="btn btn--secondary" data-action="refresh-progress">Refresh Progress</button>
+            </div>
+          </div>`;
+      }
+
+      return `
+        <div class="card">
+          <h2>Installation</h2>
+          <p class="readiness">
+            <strong>${assigned} of ${total}</strong> host(s) with roles assigned
+            &nbsp;&middot;&nbsp;
+            VIPs: <strong>${vipsOk ? "configured" : "not configured"}</strong>
+          </p>
+          <div class="btn-row">
+            <button class="btn btn--primary" data-action="show-confirm"
+              ${canInstall() ? "" : "disabled"}>
+              Start Installation
+            </button>
+          </div>
+          ${!canInstall() ? `<p class="small muted mt-sm">Assign roles to all hosts and configure VIPs before installing.</p>` : ""}
+        </div>`;
+    }
+
+    function renderConfirmDialog() {
+      return `
+        <div class="confirm-overlay">
+          <div class="confirm-dialog">
+            <h2>Confirm Installation</h2>
+            <p>This will begin installing OpenShift on the cluster. This action cannot be undone.</p>
+            <div class="btn-row">
+              <button class="btn btn--secondary" data-action="cancel-confirm">Cancel</button>
+              <button class="btn btn--danger" data-action="confirm-install">Confirm</button>
+            </div>
+          </div>
+        </div>`;
+    }
+
+    /* ---------- Initial render ---------- */
+    render();
+  </script>
+</body>
+</html>

--- a/assisted_service_mcp/src/tools/cluster_setup.html
+++ b/assisted_service_mcp/src/tools/cluster_setup.html
@@ -149,7 +149,8 @@
       padding: 0.45rem 0.55rem;
     }
     thead th {
-      background: #f3f3f3;
+      background: var(--bg-surface);
+      color: var(--text-muted);
       font-weight: 600;
       white-space: nowrap;
     }
@@ -162,6 +163,16 @@
       font: inherit;
       font-size: 0.85rem;
       padding: 0.25rem 0.4rem;
+      background: var(--bg-surface);
+      color: var(--text-primary);
+      border: 1px solid var(--border);
+      -webkit-appearance: none;
+      appearance: none;
+      border-radius: 0.25rem;
+    }
+    .role-select option {
+      background: var(--bg-surface);
+      color: var(--text-primary);
       border: 1px solid var(--border);
       border-radius: 0.25rem;
       background: #fff;
@@ -202,6 +213,7 @@
       padding: 0.5rem 0.65rem;
       font: inherit;
       color: var(--text-primary);
+      background: var(--bg-surface);
       background: #fff;
     }
     .input:focus {
@@ -445,33 +457,35 @@
       window.mcpApp = app;
 
       function trySetCluster(id) {
-        if (id && typeof id === "string" && id.length > 8 && !state.clusterId) {
+        if (id && typeof id === "string" && id.length > 8) {
           state.clusterId = id;
           render();
           loadHosts();
+          return true;
         }
+        return false;
       }
 
-      app.ontoolinput = (params) => {
-        const args = params.arguments || params.params?.arguments || {};
-        trySetCluster(args.cluster_id);
-      };
-
-      app.ontoolresult = (params) => {
-        const sc = params.structuredContent || {};
-        trySetCluster(sc.cluster_id);
-        if (!state.clusterId && sc.result) {
+      function extractClusterId(obj) {
+        if (!obj || typeof obj !== "object") return;
+        if (trySetCluster(obj.cluster_id)) return;
+        if (trySetCluster(obj.arguments?.cluster_id)) return;
+        if (trySetCluster(obj.params?.arguments?.cluster_id)) return;
+        const sc = obj.structuredContent || {};
+        if (trySetCluster(sc.cluster_id)) return;
+        if (sc.result) {
           try {
             const parsed = typeof sc.result === "string" ? JSON.parse(sc.result) : sc.result;
-            trySetCluster(parsed.cluster_id);
+            if (trySetCluster(parsed.cluster_id)) return;
           } catch {}
         }
-        if (!state.clusterId) {
-          const content = params.content || sc.content || [];
-          const txt = (Array.isArray(content) ? content : []).find(c => c.type === "text")?.text || "";
-          try { trySetCluster(JSON.parse(txt).cluster_id); } catch {}
-        }
-      };
+        const content = obj.content || sc.content || [];
+        const txt = (Array.isArray(content) ? content : []).find(c => c.type === "text")?.text || "";
+        try { trySetCluster(JSON.parse(txt).cluster_id); } catch {}
+      }
+
+      app.ontoolinput = (params) => { if (!state.clusterId) extractClusterId(params); };
+      app.ontoolresult = (params) => { if (!state.clusterId) extractClusterId(params); };
     }).catch(() => {});
 
     async function callTool(name, args = {}) {
@@ -515,6 +529,7 @@
       state.discoveryIsoUrl = data.discovery_iso_url || null;
       setStatus("Loaded " + state.hosts.length + " host(s).", "success");
       render();
+      refreshProgress();
     }
 
     async function setHostRole(hostId, role) {
@@ -618,6 +633,16 @@
     }
 
     /* ---------- Readiness checks ---------- */
+    const IN_PROGRESS_STATUSES = new Set([
+      "installing", "preparing-for-installation", "finalizing",
+      "update-image-started", "installing-pending-user-action",
+    ]);
+    function isInstallInProgress() {
+      return state.isStartingInstallation || IN_PROGRESS_STATUSES.has(state.installationStatus);
+    }
+    function isSno() {
+      return state.hosts.length <= 1;
+    }
     function hostsWithRoles() {
       return state.hosts.filter(h => h.role && h.role !== "auto-assign");
     }
@@ -627,9 +652,8 @@
     function canInstall() {
       return state.hosts.length > 0
         && hostsWithRoles().length === state.hosts.length
-        && vipsConfigured()
-        && !state.isStartingInstallation
-        && state.installationStatus !== "installing"
+        && (isSno() || vipsConfigured())
+        && !isInstallInProgress()
         && state.installationStatus !== "installed";
     }
 
@@ -787,6 +811,7 @@
     }
 
     function renderVipsSection() {
+      if (isSno()) return "";
       return `
         <div class="card">
           <h2>Virtual IPs (VIPs)</h2>
@@ -841,7 +866,7 @@
           </div>`;
       }
 
-      if (state.installationStatus === "installing" || state.isStartingInstallation) {
+      if (isInstallInProgress()) {
         return `
           <div class="card">
             <h2>Installation</h2>
@@ -863,8 +888,7 @@
           <h2>Installation</h2>
           <p class="readiness">
             <strong>${assigned} of ${total}</strong> host(s) with roles assigned
-            &nbsp;&middot;&nbsp;
-            VIPs: <strong>${vipsOk ? "configured" : "not configured"}</strong>
+            ${isSno() ? "" : `&nbsp;&middot;&nbsp; VIPs: <strong>${vipsOk ? "configured" : "not configured"}</strong>`}
           </p>
           <div class="btn-row">
             <button class="btn btn--primary" data-action="show-confirm"

--- a/assisted_service_mcp/src/tools/cluster_setup.html
+++ b/assisted_service_mcp/src/tools/cluster_setup.html
@@ -488,11 +488,17 @@
       app.ontoolresult = (params) => { if (!state.clusterId) extractClusterId(params); };
     }).catch(() => {});
 
+    function stripFollowUps(raw) {
+      if (!raw) return raw;
+      const idx = raw.indexOf("\n\n[IMPORTANT");
+      return idx !== -1 ? raw.substring(0, idx) : raw;
+    }
+
     async function callTool(name, args = {}) {
       if (!window.mcpApp) return null;
       try {
         const result = await window.mcpApp.callServerTool({ name, arguments: args });
-        const text = result.content?.find(c => c.type === "text")?.text;
+        const text = stripFollowUps(result.content?.find(c => c.type === "text")?.text);
         if (!text) return null;
         try { return JSON.parse(text); } catch { return text; }
       } catch (err) {

--- a/assisted_service_mcp/src/tools/cluster_setup.html
+++ b/assisted_service_mcp/src/tools/cluster_setup.html
@@ -488,18 +488,11 @@
       app.ontoolresult = (params) => { if (!state.clusterId) extractClusterId(params); };
     }).catch(() => {});
 
-    function stripFollowUps(raw) {
-      if (!raw) return raw;
-      const idx = raw.indexOf("\n\n[IMPORTANT");
-      return idx !== -1 ? raw.substring(0, idx) : raw;
-    }
-
     async function callTool(name, args = {}) {
       if (!window.mcpApp) return null;
       try {
         const result = await window.mcpApp.callServerTool({ name, arguments: args });
-        const raw = result.content?.find(c => c.type === "text")?.text;
-        const text = stripFollowUps(raw);
+        const text = result.content?.find(c => c.type === "text")?.text;
         if (!text) return null;
         try { return JSON.parse(text); } catch { return text; }
       } catch (err) {

--- a/assisted_service_mcp/src/tools/cluster_setup.html
+++ b/assisted_service_mcp/src/tools/cluster_setup.html
@@ -3,9 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="light dark" />
   <title>OCP Admin — Cluster Setup</title>
   <style>
     :root {
+      color-scheme: light dark;
       --font-body: "Red Hat Text", "Noto Sans", "Segoe UI", sans-serif;
       --font-heading: "Red Hat Display", "Noto Sans", "Segoe UI", sans-serif;
       --sp-2xs: 0.25rem;
@@ -25,11 +27,28 @@
       --color-warning: #f0ab00;
     }
 
+    [data-theme="dark"] {
+      --bg-shell: #1e1e1e;
+      --bg-surface: #2a2a2a;
+      --text-primary: #e0e0e0;
+      --text-muted: #a0a0a0;
+      --border: #444;
+      --color-primary: #4da3ff;
+      --color-success: #5cb85c;
+      --color-error: #f06560;
+      --color-warning: #f5c242;
+      --bg-banner: #1a2a3a;
+      --bg-banner-success: #1a2e1a;
+      --bg-banner-error: #2e1a1a;
+      --bg-banner-warning: #2e2a1a;
+    }
+
     *, *::before, *::after { box-sizing: border-box; }
+
+    html, body { background: transparent; }
 
     body {
       margin: 0;
-      background: var(--bg-shell);
       color: var(--text-primary);
       font-family: var(--font-body);
       font-size: 14px;
@@ -65,15 +84,15 @@
     /* Status banner */
     .banner {
       border-left: 3px solid var(--color-primary);
-      background: #f0f8ff;
+      background: var(--bg-banner, #f0f8ff);
       border-radius: 0.25rem;
       padding: var(--sp-sm) var(--sp-md);
       margin-bottom: var(--sp-md);
       font-size: 0.9rem;
     }
-    .banner--success { border-left-color: var(--color-success); background: #edf8ef; }
-    .banner--error   { border-left-color: var(--color-error);   background: #faeae8; }
-    .banner--warning { border-left-color: var(--color-warning); background: #fff8e7; }
+    .banner--success { border-left-color: var(--color-success); background: var(--bg-banner-success, #edf8ef); color: var(--text-primary); }
+    .banner--error   { border-left-color: var(--color-error);   background: var(--bg-banner-error, #faeae8); color: var(--text-primary); }
+    .banner--warning { border-left-color: var(--color-warning); background: var(--bg-banner-warning, #fff8e7); color: var(--text-primary); }
     .banner[hidden] { display: none; }
 
     /* Card sections */
@@ -156,8 +175,8 @@
       border-radius: 999px;
       font-weight: 500;
     }
-    .badge--assigned { background: #edf8ef; color: var(--color-success); }
-    .badge--pending  { background: #fff8e7; color: #8a6d00; }
+    .badge--assigned { background: var(--bg-banner-success, #edf8ef); color: var(--color-success); }
+    .badge--pending  { background: var(--bg-banner-warning, #fff8e7); color: var(--color-warning); }
 
     /* Form elements */
     .form-row {
@@ -292,9 +311,8 @@
     }
     .confirm-dialog .btn-row { justify-content: flex-end; }
 
-    /* Installed banner */
     .success-banner {
-      background: #edf8ef;
+      background: var(--bg-banner-success, #edf8ef);
       border: 1px solid var(--color-success);
       border-radius: 0.375rem;
       padding: var(--sp-md) var(--sp-lg);
@@ -304,7 +322,7 @@
       font-size: 1rem;
     }
     .error-banner {
-      background: #faeae8;
+      background: var(--bg-banner-error, #faeae8);
       border: 1px solid var(--color-error);
       border-radius: 0.375rem;
       padding: var(--sp-md) var(--sp-lg);
@@ -334,6 +352,31 @@
       margin-left: var(--sp-xs);
     }
     @keyframes spin { to { transform: rotate(360deg); } }
+
+    .follow-ups {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: var(--sp-md);
+      padding-top: var(--sp-sm);
+      border-top: 1px solid var(--border);
+    }
+
+    .follow-ups button {
+      background: var(--bg-surface);
+      color: var(--text-primary);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 6px 14px;
+      font-size: 12px;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+    }
+
+    .follow-ups button:hover {
+      border-color: var(--color-primary);
+      color: var(--color-primary);
+    }
   </style>
 </head>
 <body>
@@ -364,27 +407,69 @@
       return d.innerHTML;
     }
 
+    async function suggestFollowUp(promptText) {
+      if (window.openai?.sendFollowUpMessage) {
+        await window.openai.sendFollowUpMessage({ prompt: promptText });
+      } else if (window.mcpApp) {
+        await window.mcpApp.sendMessage({
+          role: "user",
+          content: [{ type: "text", text: promptText }]
+        });
+      }
+    }
+
+    function followUpHtml(prompts) {
+      return `<div class="follow-ups">${prompts.map(p =>
+        `<button onclick="suggestFollowUp('${p.replace(/'/g, "\\'")}')">${esc(p)}</button>`
+      ).join("")}</div>`;
+    }
+    window.suggestFollowUp = suggestFollowUp;
+
     /* ---------- MCP SDK ---------- */
     import("https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.0/app-with-deps").then(module => {
       const App = module.App || module.default?.App || module.default;
       const app = new (App.App || App)({ name: "Cluster Setup", version: "1.0.0" });
-      app.connect();
+      const applyDocTheme = module.applyDocumentTheme || module.default?.applyDocumentTheme;
+      const applyStyles = module.applyHostStyleVariables || module.default?.applyHostStyleVariables;
+      app.connect().then(() => {
+        try {
+          const ctx = app.getHostContext?.();
+          if (ctx?.theme && applyDocTheme) applyDocTheme(ctx.theme);
+          if (ctx?.styles?.variables && applyStyles) applyStyles(ctx.styles.variables);
+        } catch {}
+      });
+      app.onhostcontextchanged = (ctx) => {
+        if (ctx.theme && applyDocTheme) applyDocTheme(ctx.theme);
+        if (ctx?.styles?.variables && applyStyles) applyStyles(ctx.styles.variables);
+      };
       window.mcpApp = app;
 
-      app.ontoolinput = (params) => {
-        const args = params.arguments;
-        if (args?.cluster_id && typeof args.cluster_id === "string") {
-          state.clusterId = args.cluster_id;
+      function trySetCluster(id) {
+        if (id && typeof id === "string" && id.length > 8 && !state.clusterId) {
+          state.clusterId = id;
           render();
           loadHosts();
         }
+      }
+
+      app.ontoolinput = (params) => {
+        const args = params.arguments || params.params?.arguments || {};
+        trySetCluster(args.cluster_id);
       };
+
       app.ontoolresult = (params) => {
-        const sc = params.structuredContent;
-        if (sc?.cluster_id && typeof sc.cluster_id === "string" && !state.clusterId) {
-          state.clusterId = sc.cluster_id;
-          render();
-          loadHosts();
+        const sc = params.structuredContent || {};
+        trySetCluster(sc.cluster_id);
+        if (!state.clusterId && sc.result) {
+          try {
+            const parsed = typeof sc.result === "string" ? JSON.parse(sc.result) : sc.result;
+            trySetCluster(parsed.cluster_id);
+          } catch {}
+        }
+        if (!state.clusterId) {
+          const content = params.content || sc.content || [];
+          const txt = (Array.isArray(content) ? content : []).find(c => c.type === "text")?.text || "";
+          try { trySetCluster(JSON.parse(txt).cluster_id); } catch {}
         }
       };
     }).catch(() => {});
@@ -599,6 +684,19 @@
       return `<div class="banner ${cls}">${esc(state.statusMessage)}</div>`;
     }
 
+    function renderSetupFollowUps() {
+      const prompts = [];
+      if (state.installationStatus === "installed") {
+        prompts.push("Show this cluster in the inventory");
+      } else if (state.installationStatus === "installing") {
+        prompts.push("Show cluster events for troubleshooting");
+      } else if (state.hosts.length > 0 && !state.installationStatus) {
+        prompts.push("Check if hosts have registered after booting from the discovery ISO");
+        prompts.push("Monitor the installation progress");
+      }
+      return prompts.length ? followUpHtml(prompts) : "";
+    }
+
     function renderDashboard() {
       return `
         <h1>Cluster Setup</h1>
@@ -608,7 +706,8 @@
         ${renderHostsSection()}
         ${renderVipsSection()}
         ${renderInstallSection()}
-        ${state.showInstallConfirm ? renderConfirmDialog() : ""}`;
+        ${state.showInstallConfirm ? renderConfirmDialog() : ""}
+        ${renderSetupFollowUps()}`;
     }
 
     function renderDiscoveryIso() {

--- a/assisted_service_mcp/src/tools/cluster_setup.html
+++ b/assisted_service_mcp/src/tools/cluster_setup.html
@@ -488,11 +488,18 @@
       app.ontoolresult = (params) => { if (!state.clusterId) extractClusterId(params); };
     }).catch(() => {});
 
+    function stripFollowUps(raw) {
+      if (!raw) return raw;
+      const idx = raw.indexOf("\n\n[IMPORTANT");
+      return idx !== -1 ? raw.substring(0, idx) : raw;
+    }
+
     async function callTool(name, args = {}) {
       if (!window.mcpApp) return null;
       try {
         const result = await window.mcpApp.callServerTool({ name, arguments: args });
-        const text = result.content?.find(c => c.type === "text")?.text;
+        const raw = result.content?.find(c => c.type === "text")?.text;
+        const text = stripFollowUps(raw);
         if (!text) return null;
         try { return JSON.parse(text); } catch { return text; }
       } catch (err) {

--- a/assisted_service_mcp/src/tools/cluster_tools.py
+++ b/assisted_service_mcp/src/tools/cluster_tools.py
@@ -1,5 +1,6 @@
 """Cluster management tools for Assisted Service MCP Server."""
 
+import json
 from typing import Annotated, Callable
 from pydantic import Field
 
@@ -398,3 +399,61 @@ async def analyze_cluster_logs(
     client = InventoryClient(get_access_token_func())
     results = await analyze_cluster(cluster_id=cluster_id, api_client=client)
     return "\n\n".join([str(r) for r in results])
+
+
+@track_tool_usage()
+async def get_installation_progress(
+    get_access_token_func: Callable[[], str],
+    cluster_id: Annotated[
+        str,
+        Field(description="The unique identifier of the cluster to check."),
+    ],
+) -> str:
+    """Get installation status and progress for a cluster.
+
+    Returns the current installation status, progress percentage, and
+    descriptive status info. Use this to monitor a running installation
+    after calling install_cluster. Typical installations take 45-60 minutes.
+
+    Prerequisites:
+        - Cluster with installation started (from install_cluster)
+
+    Returns:
+        str: JSON with status, progress (0-100), and status_info.
+    """
+    log.info("Getting installation progress for cluster %s", cluster_id)
+    client = InventoryClient(get_access_token_func())
+    cluster = await client.get_cluster(cluster_id)
+
+    progress_pct = 0
+    if hasattr(cluster, "progress") and cluster.progress:
+        progress_pct = getattr(
+            cluster.progress, "installing_stage_percentage", 0
+        ) or 0
+
+    result = {
+        "status": getattr(cluster, "status", "unknown"),
+        "progress": progress_pct,
+        "status_info": getattr(cluster, "status_info", ""),
+    }
+    log.info(
+        "Cluster %s: status=%s progress=%d%%",
+        cluster_id,
+        result["status"],
+        result["progress"],
+    )
+    return json.dumps(result)
+
+
+async def load_creator_dashboard(
+    _get_access_token_func: Callable[[], str],
+) -> str:
+    """Open the Cluster Creator dashboard.
+
+    Use when the user wants to create a new self-managed OpenShift cluster.
+    This opens the interactive creation form.
+
+    Returns:
+        str: Confirmation that the dashboard loaded.
+    """
+    return "Cluster Creator dashboard loaded."

--- a/assisted_service_mcp/src/tools/cluster_tools.py
+++ b/assisted_service_mcp/src/tools/cluster_tools.py
@@ -428,7 +428,7 @@ async def get_installation_progress(
     progress_pct = 0
     if hasattr(cluster, "progress") and cluster.progress:
         progress_pct = getattr(
-            cluster.progress, "installing_stage_percentage", 0
+            cluster.progress, "total_percentage", 0
         ) or 0
 
     result = {

--- a/assisted_service_mcp/src/tools/cluster_tools.py
+++ b/assisted_service_mcp/src/tools/cluster_tools.py
@@ -20,6 +20,7 @@ from assisted_service_mcp.src.tools.followups import (
 @track_tool_usage()
 async def cluster_info(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str,
         Field(
@@ -48,11 +49,17 @@ async def cluster_info(
     result = await client.get_cluster(cluster_id=cluster_id)
     log.info("Successfully retrieved cluster information for %s", cluster_id)
     status = getattr(result, "status", "")
-    return result.to_str() + cluster_info_followups(status)
+    output = result.to_str()
+    if not ui_supported:
+        output += cluster_info_followups(status)
+    return output
 
 
 @track_tool_usage()
-async def list_clusters(get_access_token_func: Callable[[], str]) -> str:
+async def list_clusters(
+    get_access_token_func: Callable[[], str],
+    ui_supported: bool,
+) -> str:
     """List all clusters for the current user.
 
     Retrieves a summary of all OpenShift clusters associated with your account. This provides
@@ -80,7 +87,10 @@ async def list_clusters(get_access_token_func: Callable[[], str]) -> str:
     ]
     log.info("Successfully retrieved %s clusters", len(resp))
     if not resp:
-        return "No clusters found." + list_clusters_followups(resp)
+        output = "No clusters found."
+        if not ui_supported:
+            output += list_clusters_followups(resp)
+        return output
 
     formatted_output = ""
     for cluster in resp:
@@ -89,12 +99,15 @@ async def list_clusters(get_access_token_func: Callable[[], str]) -> str:
         formatted_output += f"- Openshift version: {cluster['openshift_version']}\n"
         formatted_output += f"- Status: {cluster['status']}\n\n"
 
-    return formatted_output + list_clusters_followups(resp)
+    if not ui_supported:
+        formatted_output += list_clusters_followups(resp)
+    return formatted_output
 
 
 @track_tool_usage()
 async def create_cluster(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     name: Annotated[str, Field(description="The name of the new cluster.")],
     version: Annotated[
         str,
@@ -166,12 +179,10 @@ async def create_cluster(  # pylint: disable=too-many-arguments,too-many-positio
         platform,
     )
 
-    # Set default cpu_architecture if not provided
     if cpu_architecture is None:
         cpu_architecture = "x86_64"
 
     if platform:
-        # Check for invalid combination: single_node = true and platform is specified and not "none"
         if single_node is True and platform != "none":
             return "Platform must be set to 'none' for single-node clusters"
     else:
@@ -181,7 +192,6 @@ async def create_cluster(  # pylint: disable=too-many-arguments,too-many-positio
 
     client = InventoryClient(get_access_token_func())
 
-    # Prepare cluster parameters
     cluster_params = {
         "base_dns_domain": base_domain,
         "tags": "chatbot",
@@ -198,7 +208,6 @@ async def create_cluster(  # pylint: disable=too-many-arguments,too-many-positio
 
     log.info("Successfully created cluster %s with ID: %s", name, cluster.id)
 
-    # Prepare infra env parameters
     infraenv_params = {
         "cluster_id": cluster.id,
         "openshift_version": cluster.openshift_version,
@@ -213,12 +222,16 @@ async def create_cluster(  # pylint: disable=too-many-arguments,too-many-positio
         cluster.id,
         infraenv.id,
     )
-    return cluster.id + create_cluster_followups()
+    output = cluster.id
+    if not ui_supported:
+        output += create_cluster_followups()
+    return output
 
 
 @track_tool_usage()
 async def set_cluster_vips(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str, Field(description="The unique identifier of the cluster to configure.")
     ],
@@ -266,6 +279,7 @@ async def set_cluster_vips(
 @track_tool_usage()
 async def set_cluster_platform(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str, Field(description="The unique identifier of the cluster to configure.")
     ],
@@ -300,6 +314,7 @@ async def set_cluster_platform(
 @track_tool_usage()
 async def install_cluster(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str, Field(description="The unique identifier of the cluster to install.")
     ],
@@ -330,6 +345,7 @@ async def install_cluster(
 @track_tool_usage()
 async def set_cluster_ssh_key(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str, Field(description="The unique identifier of the cluster to update.")
     ],
@@ -357,14 +373,11 @@ async def set_cluster_ssh_key(
     log.info("Setting SSH public key for cluster %s", cluster_id)
     client = InventoryClient(get_access_token_func())
 
-    # Import helper function here to avoid circular imports
     from assisted_service_mcp.src.tools.shared_helpers import _get_cluster_infra_env_id
 
-    # Update the cluster with the new SSH public key
     result = await client.update_cluster(cluster_id, ssh_public_key=ssh_public_key)
     log.info("Successfully updated cluster %s with new SSH key", cluster_id)
 
-    # Get the InfraEnv ID and update it
     try:
         infra_env_id = await _get_cluster_infra_env_id(client, cluster_id)
     except ValueError as e:
@@ -387,11 +400,12 @@ async def set_cluster_ssh_key(
 @track_tool_usage()
 async def analyze_cluster_logs(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[str, Field(description="The ID of the cluster")],
 ) -> str:
     """Analyze Assisted Installer logs for a cluster and summarize findings.
 
-    Runs a set of built‑in log analysis signatures against the cluster’s collected
+    Runs a set of built‑in log analysis signatures against the cluster's collected
     logs (controller logs, bootstrap/control‑plane logs, and must‑gather content
     when available). The results highlight common misconfigurations and known
     error patterns to speed up triage of failed or degraded installations.
@@ -411,6 +425,7 @@ async def analyze_cluster_logs(
 @track_tool_usage()
 async def get_installation_progress(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str,
         Field(description="The unique identifier of the cluster to check."),
@@ -449,18 +464,7 @@ async def get_installation_progress(
         result["status"],
         result["progress"],
     )
-    return json.dumps(result) + installation_progress_followups(result["status"])
-
-
-async def load_creator_dashboard(
-    _get_access_token_func: Callable[[], str],
-) -> str:
-    """Open the Cluster Creator dashboard.
-
-    Use when the user wants to create a new self-managed OpenShift cluster.
-    This opens the interactive creation form.
-
-    Returns:
-        str: Confirmation that the dashboard loaded.
-    """
-    return "Cluster Creator dashboard loaded."
+    output = json.dumps(result)
+    if not ui_supported:
+        output += installation_progress_followups(result["status"])
+    return output

--- a/assisted_service_mcp/src/tools/cluster_tools.py
+++ b/assisted_service_mcp/src/tools/cluster_tools.py
@@ -9,6 +9,12 @@ from assisted_service_mcp.src.service_client.assisted_service_api import Invento
 from assisted_service_mcp.src.service_client.helpers import Helpers
 from assisted_service_mcp.src.logger import log
 from assisted_service_mcp.src.utils.log_analyzer.main import analyze_cluster
+from assisted_service_mcp.src.tools.followups import (
+    cluster_info_followups,
+    create_cluster_followups,
+    installation_progress_followups,
+    list_clusters_followups,
+)
 
 
 @track_tool_usage()
@@ -41,7 +47,8 @@ async def cluster_info(
     client = InventoryClient(get_access_token_func())
     result = await client.get_cluster(cluster_id=cluster_id)
     log.info("Successfully retrieved cluster information for %s", cluster_id)
-    return result.to_str()
+    status = getattr(result, "status", "")
+    return result.to_str() + cluster_info_followups(status)
 
 
 @track_tool_usage()
@@ -73,7 +80,7 @@ async def list_clusters(get_access_token_func: Callable[[], str]) -> str:
     ]
     log.info("Successfully retrieved %s clusters", len(resp))
     if not resp:
-        return "No clusters found."
+        return "No clusters found." + list_clusters_followups(resp)
 
     formatted_output = ""
     for cluster in resp:
@@ -82,7 +89,7 @@ async def list_clusters(get_access_token_func: Callable[[], str]) -> str:
         formatted_output += f"- Openshift version: {cluster['openshift_version']}\n"
         formatted_output += f"- Status: {cluster['status']}\n\n"
 
-    return formatted_output
+    return formatted_output + list_clusters_followups(resp)
 
 
 @track_tool_usage()
@@ -206,7 +213,7 @@ async def create_cluster(  # pylint: disable=too-many-arguments,too-many-positio
         cluster.id,
         infraenv.id,
     )
-    return cluster.id
+    return cluster.id + create_cluster_followups()
 
 
 @track_tool_usage()
@@ -442,7 +449,7 @@ async def get_installation_progress(
         result["status"],
         result["progress"],
     )
-    return json.dumps(result)
+    return json.dumps(result) + installation_progress_followups(result["status"])
 
 
 async def load_creator_dashboard(

--- a/assisted_service_mcp/src/tools/cluster_tools.py
+++ b/assisted_service_mcp/src/tools/cluster_tools.py
@@ -104,6 +104,23 @@ async def list_clusters(
     return formatted_output
 
 
+async def open_cluster_creator(
+    _get_access_token_func: Callable[[], str],
+    ui_supported: bool,
+) -> str:
+    """Open the Cluster Creator dashboard.
+
+    Use when the user wants to create a new self-managed OpenShift cluster.
+    This opens the interactive creation form where the user can configure
+    all cluster parameters. After calling this, call create_cluster to
+    open the interactive Creator UI form.
+
+    Returns:
+        str: Instruction to proceed with create_cluster.
+    """
+    return "Cluster Creator dashboard loaded."
+
+
 @track_tool_usage()
 async def create_cluster(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     get_access_token_func: Callable[[], str],

--- a/assisted_service_mcp/src/tools/download_tools.py
+++ b/assisted_service_mcp/src/tools/download_tools.py
@@ -45,6 +45,7 @@ def format_presigned_url(presigned_url: models.PresignedUrl) -> dict[str, Any]:
 @track_tool_usage()
 async def cluster_iso_download_url(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str,
         Field(
@@ -120,6 +121,7 @@ async def cluster_iso_download_url(
 @track_tool_usage()
 async def cluster_credentials_download_url(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str,
         Field(
@@ -181,6 +183,7 @@ async def cluster_credentials_download_url(
 @track_tool_usage()
 async def cluster_logs_download_url(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str,
         Field(description="The unique identifier of the cluster to get logs for."),

--- a/assisted_service_mcp/src/tools/event_tools.py
+++ b/assisted_service_mcp/src/tools/event_tools.py
@@ -11,6 +11,7 @@ from assisted_service_mcp.src.logger import log
 @track_tool_usage()
 async def cluster_events(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str,
         Field(description="The unique identifier of the cluster to get events for."),
@@ -44,6 +45,7 @@ async def cluster_events(
 @track_tool_usage()
 async def host_events(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str,
         Field(description="The unique identifier of the cluster containing the host."),

--- a/assisted_service_mcp/src/tools/followups.py
+++ b/assisted_service_mcp/src/tools/followups.py
@@ -1,0 +1,150 @@
+"""Contextual follow-up question generators for MCP tool responses.
+
+Each function returns a formatted text block of suggested next steps
+based on the current state (cluster status, host count, etc.). The LLM
+reads these and presents them as a structured numbered list in its reply.
+"""
+
+from typing import Any
+
+SETUP_STATUSES = frozenset({"pending-for-input", "insufficient", "ready"})
+INSTALLING_STATUSES = frozenset({
+    "installing",
+    "preparing-for-installation",
+    "installing-pending-user-action",
+    "finalizing",
+})
+INSTALLED_STATUSES = frozenset({"installed", "adding-hosts"})
+ERROR_STATUSES = frozenset({"error", "cancelled"})
+
+
+def _format(steps: list[str]) -> str:
+    if not steps:
+        return ""
+    numbered = "\n".join(f"{i}. {s}" for i, s in enumerate(steps, 1))
+    return (
+        "\n\n[IMPORTANT — After presenting the information above, you MUST "
+        "include the following suggested next steps in your response. "
+        "Present them exactly as a numbered list under a "
+        '"Suggested next steps:" heading.]\n'
+        f"{numbered}"
+    )
+
+
+def list_clusters_followups(clusters: list[dict[str, Any]]) -> str:
+    """Follow-ups after listing clusters."""
+    if not clusters:
+        return _format([
+            "Create a cluster: would you like to create a new OpenShift cluster?",
+        ])
+
+    steps = [
+        "Cluster details: get more details about a specific cluster?",
+    ]
+
+    has_pending = any(
+        c.get("status", "").lower() in SETUP_STATUSES for c in clusters
+    )
+    if has_pending:
+        steps.append(
+            "Cluster setup: set up one of the pending clusters?"
+        )
+
+    steps.append("New cluster: create a brand new OpenShift cluster?")
+    return _format(steps)
+
+
+def cluster_info_followups(status: str) -> str:
+    """Follow-ups after retrieving cluster details, based on status."""
+    status = (status or "").lower()
+    steps: list[str] = []
+
+    if status in SETUP_STATUSES:
+        steps = [
+            "Cluster setup: register hosts and configure networking for this cluster?",
+            "Pre-install configuration: set an SSH key or add operator bundles before setup?",
+            "Readiness check: check what's missing before this cluster can be installed?",
+        ]
+    elif status in INSTALLING_STATUSES:
+        steps = [
+            "Installation progress: check the current installation progress?",
+            "Troubleshooting: see host-level events to check if any node is having issues?",
+        ]
+    elif status in INSTALLED_STATUSES:
+        steps = [
+            "Cluster credentials: download the kubeconfig and kubeadmin password?",
+            "Verification: see the final cluster events to confirm everything completed cleanly?",
+        ]
+    elif status in ERROR_STATUSES:
+        steps = [
+            "Log analysis: analyze the cluster logs to identify what went wrong?",
+            "Event history: see the cluster events to understand the failure?",
+        ]
+
+    return _format(steps)
+
+
+def create_cluster_followups() -> str:
+    """Follow-ups after a cluster is successfully created."""
+    return _format([
+        "Pre-install configuration: add an SSH key or operator bundles "
+        "(e.g., OpenShift Virtualization, OpenShift AI) before registering hosts?",
+        "Boot a host: download the discovery ISO so you can start booting hosts?",
+        "Cluster setup: proceed to the setup wizard to register hosts and configure VIPs?",
+    ])
+
+
+def get_cluster_hosts_followups(
+    hosts: list[dict[str, Any]],
+    cluster_status: str | None,
+) -> str:
+    """Follow-ups after retrieving cluster hosts, based on host/cluster state."""
+    status = (cluster_status or "").lower()
+
+    if status in INSTALLED_STATUSES:
+        return _format([
+            "Cluster credentials: download the kubeconfig and kubeadmin password?",
+            "Access setup: show the cluster credentials so you can start using the cluster?",
+        ])
+
+    if status in INSTALLING_STATUSES:
+        return _format([
+            "Installation progress: check the current installation progress?",
+            "Troubleshooting: see host-specific events to identify any nodes that might be stuck?",
+        ])
+
+    if not hosts:
+        return _format([
+            "Host discovery: have you booted your hosts from the discovery ISO? "
+            "They should appear here once they register.",
+        ])
+
+    return _format([
+        "Role assignment: assign specific roles (master/worker) to the discovered hosts?",
+        "Network configuration: configure VIPs (API and Ingress) for this cluster before installing?",
+        "Readiness check: check if all host validations are passing before starting installation?",
+        "Static networking: configure static networking for any of the hosts?",
+    ])
+
+
+def installation_progress_followups(status: str) -> str:
+    """Follow-ups after checking installation progress."""
+    status = (status or "").lower()
+    steps: list[str] = []
+
+    if status in INSTALLING_STATUSES:
+        steps = [
+            "Event details: see cluster events for more details on what's happening?",
+            "Host troubleshooting: check host-level events for a specific node?",
+        ]
+    elif status in INSTALLED_STATUSES:
+        steps = [
+            "Cluster credentials: download the cluster credentials (kubeconfig)?",
+        ]
+    elif status in ERROR_STATUSES:
+        steps = [
+            "Log analysis: analyze the cluster logs to identify what went wrong?",
+            "Event history: see the cluster events to understand the failure?",
+        ]
+
+    return _format(steps)

--- a/assisted_service_mcp/src/tools/health_tools.py
+++ b/assisted_service_mcp/src/tools/health_tools.py
@@ -1,0 +1,45 @@
+"""Health check tools for Assisted Service MCP Server."""
+
+import json
+from typing import Callable
+
+from assisted_service_mcp.src.metrics import track_tool_usage
+from assisted_service_mcp.src.settings import get_setting
+from assisted_service_mcp.src.logger import log
+
+
+@track_tool_usage()
+async def check_prerequisites(
+    get_access_token_func: Callable[[], str],
+) -> str:
+    """Check environment prerequisites for cluster operations.
+
+    Verifies that authentication is configured and the Assisted Installer
+    API is reachable. Call this before any cluster operation to confirm
+    the environment is ready.
+
+    Returns:
+        str: JSON with offline_token_set and api_reachable flags.
+    """
+    log.info("Checking prerequisites")
+    token_set = bool(get_setting("OFFLINE_TOKEN"))
+
+    api_reachable = False
+    api_error = None
+    if token_set:
+        try:
+            get_access_token_func()
+            api_reachable = True
+        except Exception as exc:
+            api_error = str(exc)
+            log.warning("API not reachable: %s", exc)
+
+    result = {
+        "offline_token_set": token_set,
+        "api_reachable": api_reachable,
+    }
+    if api_error:
+        result["api_error"] = api_error
+
+    log.info("Prerequisites: token=%s, api=%s", token_set, api_reachable)
+    return json.dumps(result)

--- a/assisted_service_mcp/src/tools/health_tools.py
+++ b/assisted_service_mcp/src/tools/health_tools.py
@@ -11,6 +11,7 @@ from assisted_service_mcp.src.logger import log
 @track_tool_usage()
 async def check_prerequisites(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
 ) -> str:
     """Check environment prerequisites for cluster operations.
 

--- a/assisted_service_mcp/src/tools/host_tools.py
+++ b/assisted_service_mcp/src/tools/host_tools.py
@@ -14,6 +14,7 @@ from assisted_service_mcp.src.tools.followups import get_cluster_hosts_followups
 @track_tool_usage()
 async def get_cluster_hosts(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str,
         Field(description="The unique identifier of the cluster to get hosts for."),
@@ -60,12 +61,16 @@ async def get_cluster_hosts(
 
     result = {"cluster_id": cluster_id, "hosts": hosts, "discovery_iso_url": iso_url}
     log.info("Found %d host(s) for cluster %s", len(hosts), cluster_id)
-    return json.dumps(result) + get_cluster_hosts_followups(hosts, cluster_status)
+    output = json.dumps(result)
+    if not ui_supported:
+        output += get_cluster_hosts_followups(hosts, cluster_status)
+    return output
 
 
 @track_tool_usage()
 async def set_host_role(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     host_id: Annotated[
         str, Field(description="The unique identifier of the host to configure.")
     ],

--- a/assisted_service_mcp/src/tools/host_tools.py
+++ b/assisted_service_mcp/src/tools/host_tools.py
@@ -1,5 +1,6 @@
 """Host management tools for Assisted Service MCP Server."""
 
+import json
 from typing import Annotated, Callable, Literal
 from pydantic import Field
 
@@ -7,6 +8,57 @@ from assisted_service_mcp.src.metrics import track_tool_usage
 from assisted_service_mcp.src.service_client.assisted_service_api import InventoryClient
 from assisted_service_mcp.src.logger import log
 from assisted_service_mcp.src.tools.shared_helpers import _get_cluster_infra_env_id
+
+
+@track_tool_usage()
+async def get_cluster_hosts(
+    get_access_token_func: Callable[[], str],
+    cluster_id: Annotated[
+        str,
+        Field(description="The unique identifier of the cluster to get hosts for."),
+    ],
+) -> str:
+    """Get registered hosts and discovery ISO URL for a cluster.
+
+    Returns the list of hosts that have booted from the discovery ISO and
+    registered with the Assisted Installer, along with the ISO download URL
+    for adding more hosts. Use this to check host discovery status before
+    assigning roles and starting installation.
+
+    Prerequisites:
+        - Existing cluster with infrastructure environment
+
+    Returns:
+        str: JSON with hosts array and discovery_iso_url.
+    """
+    log.info("Getting hosts for cluster %s", cluster_id)
+    client = InventoryClient(get_access_token_func())
+
+    cluster = await client.get_cluster(cluster_id)
+    hosts = []
+    for host in getattr(cluster, "hosts", []) or []:
+        hosts.append({
+            "id": getattr(host, "id", ""),
+            "hostname": getattr(host, "requested_hostname", "")
+            or getattr(host, "hostname", ""),
+            "status": getattr(host, "status", "unknown"),
+            "role": getattr(host, "role", "auto-assign"),
+        })
+
+    iso_url = ""
+    try:
+        infra_envs = await client.list_infra_envs(cluster_id)
+        if infra_envs:
+            infra_env_id = infra_envs[0].get("id", "")
+            if infra_env_id:
+                presigned = await client.get_infra_env_download_url(infra_env_id)
+                iso_url = presigned.url if presigned and presigned.url else ""
+    except Exception as exc:
+        log.warning("Could not get ISO URL for cluster %s: %s", cluster_id, exc)
+
+    result = {"hosts": hosts, "discovery_iso_url": iso_url}
+    log.info("Found %d host(s) for cluster %s", len(hosts), cluster_id)
+    return json.dumps(result)
 
 
 @track_tool_usage()

--- a/assisted_service_mcp/src/tools/host_tools.py
+++ b/assisted_service_mcp/src/tools/host_tools.py
@@ -56,7 +56,7 @@ async def get_cluster_hosts(
     except Exception as exc:
         log.warning("Could not get ISO URL for cluster %s: %s", cluster_id, exc)
 
-    result = {"hosts": hosts, "discovery_iso_url": iso_url}
+    result = {"cluster_id": cluster_id, "hosts": hosts, "discovery_iso_url": iso_url}
     log.info("Found %d host(s) for cluster %s", len(hosts), cluster_id)
     return json.dumps(result)
 

--- a/assisted_service_mcp/src/tools/host_tools.py
+++ b/assisted_service_mcp/src/tools/host_tools.py
@@ -8,6 +8,7 @@ from assisted_service_mcp.src.metrics import track_tool_usage
 from assisted_service_mcp.src.service_client.assisted_service_api import InventoryClient
 from assisted_service_mcp.src.logger import log
 from assisted_service_mcp.src.tools.shared_helpers import _get_cluster_infra_env_id
+from assisted_service_mcp.src.tools.followups import get_cluster_hosts_followups
 
 
 @track_tool_usage()
@@ -35,6 +36,7 @@ async def get_cluster_hosts(
     client = InventoryClient(get_access_token_func())
 
     cluster = await client.get_cluster(cluster_id)
+    cluster_status = getattr(cluster, "status", "")
     hosts = []
     for host in getattr(cluster, "hosts", []) or []:
         hosts.append({
@@ -58,7 +60,7 @@ async def get_cluster_hosts(
 
     result = {"cluster_id": cluster_id, "hosts": hosts, "discovery_iso_url": iso_url}
     log.info("Found %d host(s) for cluster %s", len(hosts), cluster_id)
-    return json.dumps(result)
+    return json.dumps(result) + get_cluster_hosts_followups(hosts, cluster_status)
 
 
 @track_tool_usage()

--- a/assisted_service_mcp/src/tools/network_tools.py
+++ b/assisted_service_mcp/src/tools/network_tools.py
@@ -21,6 +21,7 @@ from assisted_service_mcp.src.tools.shared_helpers import _get_cluster_infra_env
 @track_tool_usage()
 async def validate_nmstate_yaml(
     _get_access_token_func: Callable[[], str],
+    _ui_supported: bool,
     nmstate_yaml: Annotated[
         str,
         Field(
@@ -47,6 +48,7 @@ async def validate_nmstate_yaml(
 @track_tool_usage()
 async def generate_nmstate_yaml(
     _get_access_token_func: Callable[[], str],
+    _ui_supported: bool,
     params: Annotated[
         NMStateTemplateParams,
         Field(
@@ -83,6 +85,7 @@ async def generate_nmstate_yaml(
 @track_tool_usage()
 async def alter_static_network_config_nmstate_for_host(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str,
         Field(description="The unique identifier of the cluster to configure."),
@@ -149,6 +152,7 @@ async def alter_static_network_config_nmstate_for_host(
 @track_tool_usage()
 async def list_static_network_config(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str,
         Field(description="The unique identifier of the cluster to query."),

--- a/assisted_service_mcp/src/tools/operator_tools.py
+++ b/assisted_service_mcp/src/tools/operator_tools.py
@@ -10,7 +10,7 @@ from assisted_service_mcp.src.logger import log
 
 
 @track_tool_usage()
-async def list_operator_bundles(get_access_token_func: Callable[[], str]) -> str:
+async def list_operator_bundles(get_access_token_func: Callable[[], str], ui_supported: bool) -> str:
     """List available operator bundles that can be added to clusters.
 
     Retrieves operator bundles that extend OpenShift cluster functionality with additional
@@ -35,6 +35,7 @@ async def list_operator_bundles(get_access_token_func: Callable[[], str]) -> str
 @track_tool_usage()
 async def add_operator_bundle_to_cluster(
     get_access_token_func: Callable[[], str],
+    ui_supported: bool,
     cluster_id: Annotated[
         str, Field(description="The unique identifier of the cluster to configure.")
     ],

--- a/assisted_service_mcp/src/tools/version_tools.py
+++ b/assisted_service_mcp/src/tools/version_tools.py
@@ -62,7 +62,7 @@ def format_version_list(versions_data: models.OpenshiftVersions) -> str:
 
 
 @track_tool_usage()
-async def list_versions(get_access_token_func: Callable[[], str]) -> str:
+async def list_versions(get_access_token_func: Callable[[], str], ui_supported: bool) -> str:
     """List all available OpenShift versions for installation as a formatted markdown table.
 
     Retrieves the latest OpenShift versions that can be installed using the Red Hat

--- a/assisted_service_mcp/utils/auth.py
+++ b/assisted_service_mcp/utils/auth.py
@@ -32,14 +32,17 @@ def get_offline_token(mcp: Any) -> str:
         log.debug("Found offline token in environment variables")
         return token
 
-    context = mcp.get_context()
-    if context and context.request_context:
-        request = context.request_context.request
-        if request is not None:
-            token = request.headers.get("OCM-Offline-Token")
-            if token:
-                log.debug("Found offline token in request headers")
-                return token
+    try:
+        context = mcp.get_context()
+        if context and context.request_context:
+            request = context.request_context.request
+            if request is not None:
+                token = request.headers.get("OCM-Offline-Token")
+                if token:
+                    log.debug("Found offline token in request headers")
+                    return token
+    except (AttributeError, RuntimeError):
+        log.debug("Request context not available (fastmcp 3.0+ or non-request context)")
 
     log.error("No offline token found in environment or request headers")
     raise RuntimeError("No offline token found in environment or request headers")
@@ -67,19 +70,21 @@ def get_access_token(
         RuntimeError: If it isn't possible to obtain or generate the access token.
     """
     log.debug("Attempting to retrieve access token")
-    # First try to get the token from the authorization header:
-    context = mcp.get_context()
-    if context and context.request_context:
-        request = context.request_context.request
-        if request is not None:
-            header = request.headers.get("Authorization")
-            if header is not None:
-                parts = header.split()
-                if len(parts) == 2 and parts[0].lower() == "bearer":
-                    log.debug("Found access token in authorization header")
-                    return parts[1]
+    try:
+        context = mcp.get_context()
+        if context and context.request_context:
+            request = context.request_context.request
+            if request is not None:
+                header = request.headers.get("Authorization")
+                if header is not None:
+                    parts = header.split()
+                    if len(parts) == 2 and parts[0].lower() == "bearer":
+                        log.debug("Found access token in authorization header")
+                        return parts[1]
+    except (AttributeError, RuntimeError):
+        log.debug("Request context not available (fastmcp 3.0+ or non-request context)")
 
-    # Now try to get the offline token, and generate a new access token from it:
+    # Try to get the offline token, and generate a new access token from it:
     log.debug("Generating new access token from offline token")
 
     # Use the provided offline token function or default to get_offline_token(mcp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "assisted-service-client>=2.41.0.post3",
-    "mcp>=1.15.0",
+    "fastmcp>=3.0",
     "netaddr>=1.3.0",
     "requests>=2.32.3",
     "retry>=0.9.2",
@@ -42,6 +42,9 @@ test = [
 performance = [
     "aiohttp>=3.8.0",
 ]
+
+[tool.setuptools.package-data]
+"assisted_service_mcp.src.tools" = ["*.html"]
 
 [tool.pylint.main]
 ignore-paths = [

--- a/tests/mcp_apps/__init__.py
+++ b/tests/mcp_apps/__init__.py
@@ -1,0 +1,1 @@
+"""MCP Apps integration tests (downstream only)."""

--- a/tests/mcp_apps/test_new_tools.py
+++ b/tests/mcp_apps/test_new_tools.py
@@ -1,0 +1,174 @@
+"""Unit tests for new MCP Apps tools."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from assisted_service_mcp.src.tools.host_tools import get_cluster_hosts
+from assisted_service_mcp.src.tools.cluster_tools import (
+    get_installation_progress,
+    load_creator_dashboard,
+)
+from assisted_service_mcp.src.tools.health_tools import check_prerequisites
+
+
+def _mock_token() -> str:
+    return "mock-access-token"
+
+
+class TestGetClusterHosts:
+    """Tests for get_cluster_hosts tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_json_with_hosts_and_iso(self) -> None:
+        mock_host = MagicMock()
+        mock_host.id = "host-1"
+        mock_host.requested_hostname = "master-0"
+        mock_host.hostname = "localhost"
+        mock_host.status = "known"
+        mock_host.role = "master"
+
+        mock_cluster = MagicMock()
+        mock_cluster.hosts = [mock_host]
+
+        mock_presigned = MagicMock()
+        mock_presigned.url = "https://example.com/iso.iso"
+
+        with patch(
+            "assisted_service_mcp.src.tools.host_tools.InventoryClient"
+        ) as MockClient:
+            client = MockClient.return_value
+            client.get_cluster = AsyncMock(return_value=mock_cluster)
+            client.list_infra_envs = AsyncMock(
+                return_value=[{"id": "infra-1"}]
+            )
+            client.get_infra_env_download_url = AsyncMock(
+                return_value=mock_presigned
+            )
+
+            result = await get_cluster_hosts(_mock_token, "cluster-1")
+
+        data = json.loads(result)
+        assert len(data["hosts"]) == 1
+        assert data["hosts"][0]["id"] == "host-1"
+        assert data["hosts"][0]["hostname"] == "master-0"
+        assert data["hosts"][0]["role"] == "master"
+        assert data["discovery_iso_url"] == "https://example.com/iso.iso"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_hosts_when_none(self) -> None:
+        mock_cluster = MagicMock()
+        mock_cluster.hosts = []
+
+        with patch(
+            "assisted_service_mcp.src.tools.host_tools.InventoryClient"
+        ) as MockClient:
+            client = MockClient.return_value
+            client.get_cluster = AsyncMock(return_value=mock_cluster)
+            client.list_infra_envs = AsyncMock(return_value=[])
+
+            result = await get_cluster_hosts(_mock_token, "cluster-1")
+
+        data = json.loads(result)
+        assert data["hosts"] == []
+        assert data["discovery_iso_url"] == ""
+
+
+class TestGetInstallationProgress:
+    """Tests for get_installation_progress tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_progress_json(self) -> None:
+        mock_progress = MagicMock()
+        mock_progress.installing_stage_percentage = 65
+
+        mock_cluster = MagicMock()
+        mock_cluster.status = "installing"
+        mock_cluster.progress = mock_progress
+        mock_cluster.status_info = "Bootstrap complete"
+
+        with patch(
+            "assisted_service_mcp.src.tools.cluster_tools.InventoryClient"
+        ) as MockClient:
+            client = MockClient.return_value
+            client.get_cluster = AsyncMock(return_value=mock_cluster)
+
+            result = await get_installation_progress(_mock_token, "cluster-1")
+
+        data = json.loads(result)
+        assert data["status"] == "installing"
+        assert data["progress"] == 65
+        assert data["status_info"] == "Bootstrap complete"
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_progress_when_no_progress_attr(self) -> None:
+        mock_cluster = MagicMock()
+        mock_cluster.status = "pending-for-input"
+        mock_cluster.progress = None
+        mock_cluster.status_info = ""
+
+        with patch(
+            "assisted_service_mcp.src.tools.cluster_tools.InventoryClient"
+        ) as MockClient:
+            client = MockClient.return_value
+            client.get_cluster = AsyncMock(return_value=mock_cluster)
+
+            result = await get_installation_progress(_mock_token, "cluster-1")
+
+        data = json.loads(result)
+        assert data["status"] == "pending-for-input"
+        assert data["progress"] == 0
+
+
+class TestCheckPrerequisites:
+    """Tests for check_prerequisites tool."""
+
+    @pytest.mark.asyncio
+    async def test_token_set_and_api_reachable(self) -> None:
+        with patch(
+            "assisted_service_mcp.src.tools.health_tools.get_setting",
+            return_value="some-token",
+        ):
+            result = await check_prerequisites(_mock_token)
+
+        data = json.loads(result)
+        assert data["offline_token_set"] is True
+        assert data["api_reachable"] is True
+
+    @pytest.mark.asyncio
+    async def test_token_not_set(self) -> None:
+        with patch(
+            "assisted_service_mcp.src.tools.health_tools.get_setting",
+            return_value=None,
+        ):
+            result = await check_prerequisites(_mock_token)
+
+        data = json.loads(result)
+        assert data["offline_token_set"] is False
+        assert data["api_reachable"] is False
+
+    @pytest.mark.asyncio
+    async def test_token_set_but_api_unreachable(self) -> None:
+        def failing_token() -> str:
+            raise RuntimeError("SSO unreachable")
+
+        with patch(
+            "assisted_service_mcp.src.tools.health_tools.get_setting",
+            return_value="some-token",
+        ):
+            result = await check_prerequisites(failing_token)
+
+        data = json.loads(result)
+        assert data["offline_token_set"] is True
+        assert data["api_reachable"] is False
+        assert "SSO unreachable" in data["api_error"]
+
+
+class TestLoadCreatorDashboard:
+    """Tests for load_creator_dashboard tool."""
+
+    @pytest.mark.asyncio
+    async def test_returns_success_text(self) -> None:
+        result = await load_creator_dashboard(_mock_token)
+        assert "dashboard loaded" in result.lower() or "loaded" in result.lower()

--- a/tests/mcp_apps/test_new_tools.py
+++ b/tests/mcp_apps/test_new_tools.py
@@ -6,23 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from assisted_service_mcp.src.tools.host_tools import get_cluster_hosts
-from assisted_service_mcp.src.tools.cluster_tools import (
-    get_installation_progress,
-    load_creator_dashboard,
-)
+from assisted_service_mcp.src.tools.cluster_tools import get_installation_progress
 from assisted_service_mcp.src.tools.health_tools import check_prerequisites
-
-FOLLOWUP_SEPARATOR = "\n\n[IMPORTANT"
 
 
 def _mock_token() -> str:
     return "mock-access-token"
-
-
-def _parse_json_before_followups(text: str) -> dict:
-    """Extract and parse the JSON portion before the follow-up separator."""
-    json_part = text.split(FOLLOWUP_SEPARATOR, 1)[0]
-    return json.loads(json_part)
 
 
 class TestGetClusterHosts:
@@ -56,15 +45,14 @@ class TestGetClusterHosts:
                 return_value=mock_presigned
             )
 
-            result = await get_cluster_hosts(_mock_token, "cluster-1")
+            result = await get_cluster_hosts(_mock_token, True, "cluster-1")
 
-        data = _parse_json_before_followups(result)
+        data = json.loads(result)
         assert len(data["hosts"]) == 1
         assert data["hosts"][0]["id"] == "host-1"
         assert data["hosts"][0]["hostname"] == "master-0"
         assert data["hosts"][0]["role"] == "master"
         assert data["discovery_iso_url"] == "https://example.com/iso.iso"
-        assert FOLLOWUP_SEPARATOR in result
 
     @pytest.mark.asyncio
     async def test_returns_empty_hosts_when_none(self) -> None:
@@ -79,12 +67,11 @@ class TestGetClusterHosts:
             client.get_cluster = AsyncMock(return_value=mock_cluster)
             client.list_infra_envs = AsyncMock(return_value=[])
 
-            result = await get_cluster_hosts(_mock_token, "cluster-1")
+            result = await get_cluster_hosts(_mock_token, True, "cluster-1")
 
-        data = _parse_json_before_followups(result)
+        data = json.loads(result)
         assert data["hosts"] == []
         assert data["discovery_iso_url"] == ""
-        assert FOLLOWUP_SEPARATOR in result
 
 
 class TestGetInstallationProgress:
@@ -106,13 +93,12 @@ class TestGetInstallationProgress:
             client = MockClient.return_value
             client.get_cluster = AsyncMock(return_value=mock_cluster)
 
-            result = await get_installation_progress(_mock_token, "cluster-1")
+            result = await get_installation_progress(_mock_token, True, "cluster-1")
 
-        data = _parse_json_before_followups(result)
+        data = json.loads(result)
         assert data["status"] == "installing"
         assert data["progress"] == 65
         assert data["status_info"] == "Bootstrap complete"
-        assert FOLLOWUP_SEPARATOR in result
 
     @pytest.mark.asyncio
     async def test_returns_zero_progress_when_no_progress_attr(self) -> None:
@@ -127,9 +113,9 @@ class TestGetInstallationProgress:
             client = MockClient.return_value
             client.get_cluster = AsyncMock(return_value=mock_cluster)
 
-            result = await get_installation_progress(_mock_token, "cluster-1")
+            result = await get_installation_progress(_mock_token, True, "cluster-1")
 
-        data = _parse_json_before_followups(result)
+        data = json.loads(result)
         assert data["status"] == "pending-for-input"
         assert data["progress"] == 0
 
@@ -143,7 +129,7 @@ class TestCheckPrerequisites:
             "assisted_service_mcp.src.tools.health_tools.get_setting",
             return_value="some-token",
         ):
-            result = await check_prerequisites(_mock_token)
+            result = await check_prerequisites(_mock_token, True)
 
         data = json.loads(result)
         assert data["offline_token_set"] is True
@@ -155,7 +141,7 @@ class TestCheckPrerequisites:
             "assisted_service_mcp.src.tools.health_tools.get_setting",
             return_value=None,
         ):
-            result = await check_prerequisites(_mock_token)
+            result = await check_prerequisites(_mock_token, True)
 
         data = json.loads(result)
         assert data["offline_token_set"] is False
@@ -170,18 +156,9 @@ class TestCheckPrerequisites:
             "assisted_service_mcp.src.tools.health_tools.get_setting",
             return_value="some-token",
         ):
-            result = await check_prerequisites(failing_token)
+            result = await check_prerequisites(failing_token, True)
 
         data = json.loads(result)
         assert data["offline_token_set"] is True
         assert data["api_reachable"] is False
         assert "SSO unreachable" in data["api_error"]
-
-
-class TestLoadCreatorDashboard:
-    """Tests for load_creator_dashboard tool."""
-
-    @pytest.mark.asyncio
-    async def test_returns_success_text(self) -> None:
-        result = await load_creator_dashboard(_mock_token)
-        assert "dashboard loaded" in result.lower() or "loaded" in result.lower()

--- a/tests/mcp_apps/test_new_tools.py
+++ b/tests/mcp_apps/test_new_tools.py
@@ -12,9 +12,17 @@ from assisted_service_mcp.src.tools.cluster_tools import (
 )
 from assisted_service_mcp.src.tools.health_tools import check_prerequisites
 
+FOLLOWUP_SEPARATOR = "\n\n[IMPORTANT"
+
 
 def _mock_token() -> str:
     return "mock-access-token"
+
+
+def _parse_json_before_followups(text: str) -> dict:
+    """Extract and parse the JSON portion before the follow-up separator."""
+    json_part = text.split(FOLLOWUP_SEPARATOR, 1)[0]
+    return json.loads(json_part)
 
 
 class TestGetClusterHosts:
@@ -31,6 +39,7 @@ class TestGetClusterHosts:
 
         mock_cluster = MagicMock()
         mock_cluster.hosts = [mock_host]
+        mock_cluster.status = "pending-for-input"
 
         mock_presigned = MagicMock()
         mock_presigned.url = "https://example.com/iso.iso"
@@ -49,17 +58,19 @@ class TestGetClusterHosts:
 
             result = await get_cluster_hosts(_mock_token, "cluster-1")
 
-        data = json.loads(result)
+        data = _parse_json_before_followups(result)
         assert len(data["hosts"]) == 1
         assert data["hosts"][0]["id"] == "host-1"
         assert data["hosts"][0]["hostname"] == "master-0"
         assert data["hosts"][0]["role"] == "master"
         assert data["discovery_iso_url"] == "https://example.com/iso.iso"
+        assert FOLLOWUP_SEPARATOR in result
 
     @pytest.mark.asyncio
     async def test_returns_empty_hosts_when_none(self) -> None:
         mock_cluster = MagicMock()
         mock_cluster.hosts = []
+        mock_cluster.status = "pending-for-input"
 
         with patch(
             "assisted_service_mcp.src.tools.host_tools.InventoryClient"
@@ -70,9 +81,10 @@ class TestGetClusterHosts:
 
             result = await get_cluster_hosts(_mock_token, "cluster-1")
 
-        data = json.loads(result)
+        data = _parse_json_before_followups(result)
         assert data["hosts"] == []
         assert data["discovery_iso_url"] == ""
+        assert FOLLOWUP_SEPARATOR in result
 
 
 class TestGetInstallationProgress:
@@ -81,7 +93,7 @@ class TestGetInstallationProgress:
     @pytest.mark.asyncio
     async def test_returns_progress_json(self) -> None:
         mock_progress = MagicMock()
-        mock_progress.installing_stage_percentage = 65
+        mock_progress.total_percentage = 65
 
         mock_cluster = MagicMock()
         mock_cluster.status = "installing"
@@ -96,10 +108,11 @@ class TestGetInstallationProgress:
 
             result = await get_installation_progress(_mock_token, "cluster-1")
 
-        data = json.loads(result)
+        data = _parse_json_before_followups(result)
         assert data["status"] == "installing"
         assert data["progress"] == 65
         assert data["status_info"] == "Bootstrap complete"
+        assert FOLLOWUP_SEPARATOR in result
 
     @pytest.mark.asyncio
     async def test_returns_zero_progress_when_no_progress_attr(self) -> None:
@@ -116,7 +129,7 @@ class TestGetInstallationProgress:
 
             result = await get_installation_progress(_mock_token, "cluster-1")
 
-        data = json.loads(result)
+        data = _parse_json_before_followups(result)
         assert data["status"] == "pending-for-input"
         assert data["progress"] == 0
 

--- a/tests/mcp_apps/test_new_tools.py
+++ b/tests/mcp_apps/test_new_tools.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from assisted_service_mcp.src.tools.host_tools import get_cluster_hosts
-from assisted_service_mcp.src.tools.cluster_tools import get_installation_progress
+from assisted_service_mcp.src.tools.cluster_tools import (
+    get_installation_progress,
+    open_cluster_creator,
+)
 from assisted_service_mcp.src.tools.health_tools import check_prerequisites
 
 
@@ -162,3 +165,17 @@ class TestCheckPrerequisites:
         assert data["offline_token_set"] is True
         assert data["api_reachable"] is False
         assert "SSO unreachable" in data["api_error"]
+
+
+class TestOpenClusterCreator:
+    """Tests for open_cluster_creator tool."""
+
+    @pytest.mark.asyncio
+    async def test_ui_supported_returns_dashboard_loaded(self) -> None:
+        result = await open_cluster_creator(_mock_token, True)
+        assert "dashboard loaded" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_text_only_also_returns_dashboard_loaded(self) -> None:
+        result = await open_cluster_creator(_mock_token, False)
+        assert "dashboard loaded" in result.lower()

--- a/tests/mcp_apps/test_resources.py
+++ b/tests/mcp_apps/test_resources.py
@@ -1,0 +1,79 @@
+"""Tests for MCP Apps UI resource registration."""
+
+import pytest
+
+from assisted_service_mcp.src.mcp import (
+    INVENTORY_HTML,
+    CREATOR_HTML,
+    SETUP_HTML,
+    INVENTORY_RESOURCE_URI,
+    CREATOR_RESOURCE_URI,
+    SETUP_RESOURCE_URI,
+    AssistedServiceMCPServer,
+)
+
+
+class TestHtmlLoading:
+    """Verify HTML dashboard files load correctly at import time."""
+
+    def test_inventory_html_is_loaded(self) -> None:
+        assert len(INVENTORY_HTML) > 100
+        assert "<!DOCTYPE html>" in INVENTORY_HTML or "<html" in INVENTORY_HTML
+
+    def test_creator_html_is_loaded(self) -> None:
+        assert len(CREATOR_HTML) > 100
+        assert "<!DOCTYPE html>" in CREATOR_HTML or "<html" in CREATOR_HTML
+
+    def test_setup_html_is_loaded(self) -> None:
+        assert len(SETUP_HTML) > 100
+        assert "<!DOCTYPE html>" in SETUP_HTML or "<html" in SETUP_HTML
+
+
+class TestResourceUris:
+    """Verify resource URI constants follow expected naming."""
+
+    def test_inventory_uri(self) -> None:
+        assert INVENTORY_RESOURCE_URI == "ui://cluster-inventory"
+
+    def test_creator_uri(self) -> None:
+        assert CREATOR_RESOURCE_URI == "ui://cluster-creator"
+
+    def test_setup_uri(self) -> None:
+        assert SETUP_RESOURCE_URI == "ui://cluster-setup"
+
+
+class TestHtmlContent:
+    """Verify HTML dashboards contain MCP Apps SDK and correct tool calls."""
+
+    def test_inventory_has_mcp_sdk(self) -> None:
+        assert "unpkg.com/@modelcontextprotocol/ext-apps" in INVENTORY_HTML
+
+    def test_creator_has_mcp_sdk(self) -> None:
+        assert "unpkg.com/@modelcontextprotocol/ext-apps" in CREATOR_HTML
+
+    def test_setup_has_mcp_sdk(self) -> None:
+        assert "unpkg.com/@modelcontextprotocol/ext-apps" in SETUP_HTML
+
+    def test_inventory_calls_list_clusters(self) -> None:
+        assert "list_clusters" in INVENTORY_HTML
+
+    def test_inventory_calls_cluster_info(self) -> None:
+        assert "cluster_info" in INVENTORY_HTML
+
+    def test_creator_calls_create_cluster(self) -> None:
+        assert "create_cluster" in CREATOR_HTML
+
+    def test_setup_calls_get_cluster_hosts(self) -> None:
+        assert "get_cluster_hosts" in SETUP_HTML
+
+    def test_setup_calls_set_host_role(self) -> None:
+        assert "set_host_role" in SETUP_HTML
+
+    def test_setup_calls_install_cluster(self) -> None:
+        assert "install_cluster" in SETUP_HTML
+
+    def test_inventory_has_send_message(self) -> None:
+        assert "sendMessage" in INVENTORY_HTML
+
+    def test_creator_has_send_message(self) -> None:
+        assert "sendMessage" in CREATOR_HTML

--- a/tests/mcp_apps/test_tool_bindings.py
+++ b/tests/mcp_apps/test_tool_bindings.py
@@ -45,7 +45,6 @@ class TestToolRegistration:
         "get_cluster_hosts",
         "get_installation_progress",
         "check_prerequisites",
-        "load_creator_dashboard",
     }
 
     def test_all_original_tools_registered(self, tool_names: list[str]) -> None:

--- a/tests/mcp_apps/test_tool_bindings.py
+++ b/tests/mcp_apps/test_tool_bindings.py
@@ -45,6 +45,7 @@ class TestToolRegistration:
         "get_cluster_hosts",
         "get_installation_progress",
         "check_prerequisites",
+        "open_cluster_creator",
     }
 
     def test_all_original_tools_registered(self, tool_names: list[str]) -> None:

--- a/tests/mcp_apps/test_tool_bindings.py
+++ b/tests/mcp_apps/test_tool_bindings.py
@@ -1,0 +1,67 @@
+"""Tests for tool-to-UI resource bindings via AppConfig."""
+
+import pytest
+
+from assisted_service_mcp.src.mcp import AssistedServiceMCPServer
+
+
+@pytest.fixture(scope="module")
+def server() -> AssistedServiceMCPServer:
+    return AssistedServiceMCPServer()
+
+
+@pytest.fixture(scope="module")
+def tool_names(server: AssistedServiceMCPServer) -> list[str]:
+    return server.list_tools_sync()
+
+
+class TestToolRegistration:
+    """Verify all expected tools are registered."""
+
+    EXPECTED_ORIGINAL_TOOLS = {
+        "cluster_info",
+        "list_clusters",
+        "create_cluster",
+        "set_cluster_vips",
+        "set_cluster_platform",
+        "install_cluster",
+        "set_cluster_ssh_key",
+        "cluster_events",
+        "host_events",
+        "cluster_iso_download_url",
+        "cluster_credentials_download_url",
+        "cluster_logs_download_url",
+        "list_versions",
+        "list_operator_bundles",
+        "add_operator_bundle_to_cluster",
+        "set_host_role",
+        "validate_nmstate_yaml",
+        "generate_nmstate_yaml",
+        "alter_static_network_config_nmstate_for_host",
+        "list_static_network_config",
+    }
+
+    EXPECTED_NEW_TOOLS = {
+        "get_cluster_hosts",
+        "get_installation_progress",
+        "check_prerequisites",
+        "load_creator_dashboard",
+    }
+
+    def test_all_original_tools_registered(self, tool_names: list[str]) -> None:
+        names_set = set(tool_names)
+        missing = self.EXPECTED_ORIGINAL_TOOLS - names_set
+        assert not missing, f"Missing original tools: {missing}"
+
+    def test_all_new_tools_registered(self, tool_names: list[str]) -> None:
+        names_set = set(tool_names)
+        missing = self.EXPECTED_NEW_TOOLS - names_set
+        assert not missing, f"Missing new tools: {missing}"
+
+    def test_total_tool_count(self, tool_names: list[str]) -> None:
+        expected_min = len(self.EXPECTED_ORIGINAL_TOOLS) + len(
+            self.EXPECTED_NEW_TOOLS
+        )
+        assert len(tool_names) >= expected_min, (
+            f"Expected at least {expected_min} tools, got {len(tool_names)}"
+        )

--- a/tests/tools/test_followups.py
+++ b/tests/tools/test_followups.py
@@ -1,0 +1,140 @@
+"""Unit tests for follow-up question generators."""
+
+import pytest
+
+from assisted_service_mcp.src.tools.followups import (
+    _format,
+    cluster_info_followups,
+    create_cluster_followups,
+    get_cluster_hosts_followups,
+    installation_progress_followups,
+    list_clusters_followups,
+)
+
+
+SEPARATOR = "\n\n[IMPORTANT"
+
+
+class TestFormat:
+    def test_empty_list_returns_empty_string(self) -> None:
+        assert _format([]) == ""
+
+    def test_single_step(self) -> None:
+        result = _format(["Do you want help?"])
+        assert result.startswith(SEPARATOR)
+        assert "1. Do you want help?" in result
+
+    def test_multiple_steps(self) -> None:
+        result = _format(["Step one", "Step two"])
+        assert "1. Step one" in result
+        assert "2. Step two" in result
+
+    def test_includes_heading_instruction(self) -> None:
+        result = _format(["Something"])
+        assert "Suggested next steps" in result
+
+
+class TestListClustersFollowups:
+    def test_no_clusters(self) -> None:
+        result = list_clusters_followups([])
+        assert "create" in result.lower()
+
+    def test_clusters_exist(self) -> None:
+        clusters = [{"name": "c1", "id": "1", "status": "ready"}]
+        result = list_clusters_followups(clusters)
+        assert "cluster details" in result.lower()
+        assert "new cluster" in result.lower()
+
+    def test_pending_cluster_suggests_setup(self) -> None:
+        clusters = [
+            {"name": "c1", "id": "1", "status": "pending-for-input"},
+            {"name": "c2", "id": "2", "status": "installed"},
+        ]
+        result = list_clusters_followups(clusters)
+        assert "cluster setup" in result.lower()
+
+    def test_no_pending_omits_setup_suggestion(self) -> None:
+        clusters = [{"name": "c1", "id": "1", "status": "installed"}]
+        result = list_clusters_followups(clusters)
+        assert "pending" not in result.lower()
+
+
+class TestClusterInfoFollowups:
+    @pytest.mark.parametrize(
+        "status",
+        ["pending-for-input", "insufficient", "ready"],
+    )
+    def test_setup_statuses(self, status: str) -> None:
+        result = cluster_info_followups(status)
+        assert "cluster setup" in result.lower()
+        assert "pre-install" in result.lower()
+
+    def test_installing_status(self) -> None:
+        result = cluster_info_followups("installing")
+        assert "installation progress" in result.lower()
+
+    def test_installed_status(self) -> None:
+        result = cluster_info_followups("installed")
+        assert "credentials" in result.lower()
+
+    @pytest.mark.parametrize("status", ["error", "cancelled"])
+    def test_error_statuses(self, status: str) -> None:
+        result = cluster_info_followups(status)
+        assert "log analysis" in result.lower()
+
+    def test_unknown_status_returns_empty(self) -> None:
+        result = cluster_info_followups("some-unknown-state")
+        assert result == ""
+
+    def test_none_status_returns_empty(self) -> None:
+        result = cluster_info_followups("")
+        assert result == ""
+
+
+class TestCreateClusterFollowups:
+    def test_contains_key_suggestions(self) -> None:
+        result = create_cluster_followups()
+        assert "pre-install configuration" in result.lower()
+        assert "boot a host" in result.lower()
+        assert "cluster setup" in result.lower()
+
+
+class TestGetClusterHostsFollowups:
+    def test_no_hosts(self) -> None:
+        result = get_cluster_hosts_followups([], None)
+        assert "host discovery" in result.lower()
+
+    def test_hosts_discovered_pending(self) -> None:
+        hosts = [{"id": "h1", "status": "known", "role": "auto-assign"}]
+        result = get_cluster_hosts_followups(hosts, "pending-for-input")
+        assert "role assignment" in result.lower()
+        assert "network configuration" in result.lower()
+
+    def test_installing(self) -> None:
+        hosts = [{"id": "h1", "status": "installing", "role": "master"}]
+        result = get_cluster_hosts_followups(hosts, "installing")
+        assert "installation progress" in result.lower()
+
+    def test_installed(self) -> None:
+        hosts = [{"id": "h1", "status": "installed", "role": "master"}]
+        result = get_cluster_hosts_followups(hosts, "installed")
+        assert "credentials" in result.lower()
+
+
+class TestInstallationProgressFollowups:
+    def test_installing(self) -> None:
+        result = installation_progress_followups("installing")
+        assert "event details" in result.lower()
+
+    def test_installed(self) -> None:
+        result = installation_progress_followups("installed")
+        assert "credentials" in result.lower()
+
+    @pytest.mark.parametrize("status", ["error", "cancelled"])
+    def test_error(self, status: str) -> None:
+        result = installation_progress_followups(status)
+        assert "log analysis" in result.lower()
+
+    def test_unknown_returns_empty(self) -> None:
+        result = installation_progress_followups("some-random")
+        assert result == ""

--- a/tests/tools/test_tools_module.py
+++ b/tests/tools/test_tools_module.py
@@ -486,7 +486,8 @@ async def test_tool_create_cluster_module() -> None:
             cpu_architecture="x86_64",
             platform="baremetal",
         )
-        assert resp == "cid-1"
+        assert resp.startswith("cid-1")
+        assert "[IMPORTANT" in resp
 
 
 @pytest.mark.asyncio
@@ -533,7 +534,8 @@ async def test_tool_create_cluster_with_none_cpu_architecture_module() -> None:
             cpu_architecture=None,  # Test None value
             platform=None,
         )
-        assert resp == "cid-2"
+        assert resp.startswith("cid-2")
+        assert "[IMPORTANT" in resp
 
         # Verify that the create_cluster was called with the default x86_64
         mock_client.create_cluster.assert_called_once()
@@ -642,7 +644,8 @@ async def test_tool_cluster_info_success() -> None:
         return_value=mock_client,
     ):
         resp = await cluster_tools.cluster_info(lambda: "t", "cid-123")
-        assert resp == cluster.to_str()
+        assert resp.startswith(cluster.to_str())
+        assert "[IMPORTANT" in resp
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_tools_module.py
+++ b/tests/tools/test_tools_module.py
@@ -35,7 +35,7 @@ async def test_tool_set_cluster_platform_module() -> None:
         ),
     ):
         resp = await cluster_tools.set_cluster_platform(
-            lambda: "test-access-token", "cid", "vsphere"
+            lambda: "test-access-token", True, "cid", "vsphere"
         )
         assert resp == "UPDATED"
 
@@ -62,7 +62,7 @@ async def test_tool_set_cluster_vips_module() -> None:
         ),
     ):
         resp = await cluster_tools.set_cluster_vips(
-            lambda: "test-access-token", "cid", "10.0.0.2", "10.0.0.3"
+            lambda: "test-access-token", True, "cid", "10.0.0.2", "10.0.0.3"
         )
         assert resp == "VIPS-UPDATED"
 
@@ -75,6 +75,7 @@ async def test_create_cluster_invalid_platform_for_sno_returns_message() -> None
     AssistedServiceMCPServer()
     resp = await cluster_tools.create_cluster(
         lambda: "t",
+        True,
         name="n",
         version="4.18.0",
         base_domain="example.com",
@@ -107,7 +108,7 @@ async def test_tool_install_cluster_module() -> None:
             return_value="test-access-token",
         ),
     ):
-        resp = await cluster_tools.install_cluster(lambda: "test-access-token", "cid")
+        resp = await cluster_tools.install_cluster(lambda: "test-access-token", True, "cid")
         assert resp == "INSTALL-TRIGGERED"
 
 
@@ -130,7 +131,7 @@ async def test_tool_cluster_events_module() -> None:
             return_value="test-access-token",
         ),
     ):
-        resp = await event_tools.cluster_events(lambda: "test-access-token", "cid")
+        resp = await event_tools.cluster_events(lambda: "test-access-token", True, "cid")
         assert json.loads(resp)["events"] == ["e1", "e2"]
 
 
@@ -153,7 +154,7 @@ async def test_tool_host_events_module() -> None:
             return_value="test-access-token",
         ),
     ):
-        resp = await event_tools.host_events(lambda: "test-access-token", "cid", "hid")
+        resp = await event_tools.host_events(lambda: "test-access-token", True, "cid", "hid")
         assert json.loads(resp)["events"] == ["h1"]
 
 
@@ -189,7 +190,7 @@ async def test_tool_cluster_iso_download_url_module() -> None:
         ),
     ):
         resp = await download_tools.cluster_iso_download_url(
-            lambda: "test-access-token", "cid"
+            lambda: "test-access-token", True, "cid"
         )
         data = json.loads(resp)
         assert data[0]["url"] == "https://u/iso"
@@ -223,7 +224,7 @@ async def test_tool_cluster_credentials_download_url_module() -> None:
         ),
     ):
         resp = await download_tools.cluster_credentials_download_url(
-            lambda: "test-access-token", "cid", "kubeconfig"
+            lambda: "test-access-token", True, "cid", "kubeconfig"
         )
         data = json.loads(resp)
         assert data["url"] == "https://u/kubeconfig"
@@ -255,7 +256,7 @@ async def test_tool_set_host_role_module() -> None:
         ),
     ):
         resp = await host_tools.set_host_role(
-            lambda: "test-access-token", "hid", "cid", "worker"
+            lambda: "test-access-token", True, "hid", "cid", "worker"
         )
         assert resp == "HOST-UPDATED"
 
@@ -282,7 +283,7 @@ async def test_tool_add_operator_bundle_module() -> None:
         ),
     ):
         resp = await operator_tools.add_operator_bundle_to_cluster(
-            lambda: "test-access-token", "cid", "virtualization"
+            lambda: "test-access-token", True, "cid", "virtualization"
         )
         assert resp == "OP-ADDED"
 
@@ -307,7 +308,7 @@ async def test_tool_list_operator_bundles_module() -> None:
             return_value="test-access-token",
         ),
     ):
-        resp = await operator_tools.list_operator_bundles(lambda: "test-access-token")
+        resp = await operator_tools.list_operator_bundles(lambda: "test-access-token", True)
         assert json.loads(resp) == bundles
 
 
@@ -321,7 +322,7 @@ async def test_tool_network_validate_nmstate_yaml_module() -> None:
     ):
         AssistedServiceMCPServer()
         resp = await network_tools.validate_nmstate_yaml(
-            lambda: "test-access-token", "interfaces: []\n"
+            lambda: "test-access-token", True, "interfaces: []\n"
         )
         assert resp == "YAML is valid"
 
@@ -348,7 +349,7 @@ async def test_alter_static_network_remove_with_none_index_raises() -> None:
     ):
         with pytest.raises(ValueError, match="index cannot be null"):
             await network_tools.alter_static_network_config_nmstate_for_host(
-                lambda: "t", "cid", None, None
+                lambda: "t", True, "cid", None, None
             )
 
 
@@ -374,7 +375,7 @@ async def test_alter_static_network_remove_with_empty_existing_raises() -> None:
     ):
         with pytest.raises(ValueError, match="empty existing static network config"):
             await network_tools.alter_static_network_config_nmstate_for_host(
-                lambda: "t", "cid", 0, None
+                lambda: "t", True, "cid", 0, None
             )
 
 
@@ -390,7 +391,7 @@ async def test_list_static_network_config_invalid_infraenv_count() -> None:
         "assisted_service_mcp.src.tools.network_tools.InventoryClient",
         return_value=mock_client,
     ):
-        resp = await network_tools.list_static_network_config(lambda: "t", "cid")
+        resp = await network_tools.list_static_network_config(lambda: "t", True, "cid")
         assert resp.startswith("ERROR:")
 
 
@@ -411,7 +412,7 @@ async def test_list_versions_happy_path() -> None:
         "assisted_service_mcp.src.tools.version_tools.InventoryClient",
         return_value=mock_client,
     ):
-        resp = await version_tools.list_versions(lambda: "t")
+        resp = await version_tools.list_versions(lambda: "t", True)
         assert "4.18.1" in resp and "Full Support" in resp
 
 
@@ -438,7 +439,7 @@ async def test_tool_network_generate_nmstate_yaml_module() -> None:
         return_value="yaml",
     ):
         resp = await network_tools.generate_nmstate_yaml(
-            lambda: "test-access-token", params
+            lambda: "test-access-token", True, params
         )
         assert resp == "yaml"
 
@@ -478,6 +479,7 @@ async def test_tool_create_cluster_module() -> None:
     ):
         resp = await cluster_tools.create_cluster(
             lambda: "test-access-token",
+            False,
             name="n",
             version="4.18.2",
             base_domain="example.com",
@@ -526,6 +528,7 @@ async def test_tool_create_cluster_with_none_cpu_architecture_module() -> None:
     ):
         resp = await cluster_tools.create_cluster(
             lambda: "test-access-token",
+            False,
             name="test-cluster",
             version="4.19.0",
             base_domain="example.com",
@@ -576,7 +579,7 @@ async def test_tool_set_cluster_ssh_key_partial_failure_module() -> None:
         ),
     ):
         resp = await cluster_tools.set_cluster_ssh_key(
-            lambda: "test-access-token", "cid", "ssh-rsa AAAA"
+            lambda: "test-access-token", True, "cid", "ssh-rsa AAAA"
         )
         assert "Cluster key updated, but boot image key update failed" in resp
 
@@ -588,7 +591,7 @@ def test_list_versions_error_branch() -> None:  # type: ignore[no-untyped-def]
             side_effect=Exception("boom"),
         ):
             try:
-                await list_versions(lambda: "token")
+                await list_versions(lambda: "token", True)
             except Exception as e:  # noqa: BLE001
                 assert "boom" in str(e)
 
@@ -602,7 +605,7 @@ def test_list_operator_bundles_error_branch() -> None:  # type: ignore[no-untype
             side_effect=Exception("boom2"),
         ):
             try:
-                await list_operator_bundles(lambda: "token")
+                await list_operator_bundles(lambda: "token", True)
             except Exception as e:  # noqa: BLE001
                 assert "boom2" in str(e)
 
@@ -622,7 +625,7 @@ def test_add_operator_bundle_to_cluster_happy() -> None:  # type: ignore[no-unty
             "assisted_service_mcp.src.tools.operator_tools.InventoryClient",
             return_value=mock_client,
         ):
-            s = await add_operator_bundle_to_cluster(lambda: "token", "cid", "bundle")
+            s = await add_operator_bundle_to_cluster(lambda: "token", True, "cid", "bundle")
             assert s == "cluster-str"
 
     asyncio.run(run())
@@ -643,7 +646,7 @@ async def test_tool_cluster_info_success() -> None:
         "assisted_service_mcp.src.tools.cluster_tools.InventoryClient",
         return_value=mock_client,
     ):
-        resp = await cluster_tools.cluster_info(lambda: "t", "cid-123")
+        resp = await cluster_tools.cluster_info(lambda: "t", False, "cid-123")
         assert resp.startswith(cluster.to_str())
         assert "[IMPORTANT" in resp
 
@@ -676,7 +679,7 @@ async def test_tool_list_clusters_formats_fields_and_defaults_version() -> None:
         "assisted_service_mcp.src.tools.cluster_tools.InventoryClient",
         return_value=mock_client,
     ):
-        resp = await cluster_tools.list_clusters(lambda: "t")
+        resp = await cluster_tools.list_clusters(lambda: "t", True)
         assert "Openshift version: 4.18.2" in resp
         assert "Openshift version: Unknown" in resp
 
@@ -713,7 +716,7 @@ async def test_tool_cluster_iso_download_url_multiple_and_zero_expiration() -> N
         "assisted_service_mcp.src.tools.download_tools.InventoryClient",
         return_value=mock_client,
     ):
-        resp = await download_tools.cluster_iso_download_url(lambda: "t", "cid")
+        resp = await download_tools.cluster_iso_download_url(lambda: "t", True, "cid")
         data = json.loads(resp)
         assert data[0]["url"] == "https://u/iso1"
         assert "expires_at" not in data[0]
@@ -734,7 +737,7 @@ async def test_tool_cluster_iso_download_url_no_infraenvs_returns_message() -> N
         "assisted_service_mcp.src.tools.download_tools.InventoryClient",
         return_value=mock_client,
     ):
-        resp = await download_tools.cluster_iso_download_url(lambda: "t", "cid")
+        resp = await download_tools.cluster_iso_download_url(lambda: "t", True, "cid")
         assert resp == "No ISO download URLs found for this cluster."
 
 
@@ -754,7 +757,7 @@ async def test_tool_cluster_credentials_download_url_error_shaping() -> None:
         return_value=mock_client,
     ):
         resp = await download_tools.cluster_credentials_download_url(
-            lambda: "t", "cid", "kubeconfig"
+            lambda: "t", True, "cid", "kubeconfig"
         )
         data = json.loads(resp)
         assert "error" in data
@@ -784,7 +787,7 @@ async def test_tool_set_cluster_ssh_key_success_path() -> None:
         ),
     ):
         resp = await cluster_tools.set_cluster_ssh_key(
-            lambda: "t", "cid", "ssh-rsa AAAA"
+            lambda: "t", True, "cid", "ssh-rsa AAAA"
         )
         assert resp == cluster.to_str()
 
@@ -804,7 +807,7 @@ async def test_tool_list_static_network_config_success() -> None:
         "assisted_service_mcp.src.tools.network_tools.InventoryClient",
         return_value=mock_client,
     ):
-        resp = await network_tools.list_static_network_config(lambda: "t", "cid")
+        resp = await network_tools.list_static_network_config(lambda: "t", True, "cid")
         arr = json.loads(resp)
         assert arr == ["cfg1", "cfg2"]
 
@@ -842,7 +845,7 @@ async def test_tool_alter_static_network_add_or_replace_success() -> None:
         ),
     ):
         resp = await network_tools.alter_static_network_config_nmstate_for_host(
-            lambda: "t", "cid", None, "interfaces: []\n"
+            lambda: "t", True, "cid", None, "interfaces: []\n"
         )
         assert resp == "UPDATED-INFRA"
         mock_client.update_infra_env.assert_awaited_once_with(

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
+name = "aiofile"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload-time = "2026-05-16T08:18:32.051Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -143,8 +155,8 @@ source = { virtual = "." }
 dependencies = [
     { name = "assisted-service-client" },
     { name = "fastapi" },
+    { name = "fastmcp" },
     { name = "jinja2" },
-    { name = "mcp" },
     { name = "nestedarchive" },
     { name = "netaddr" },
     { name = "prometheus-client" },
@@ -183,8 +195,8 @@ test = [
 requires-dist = [
     { name = "assisted-service-client", specifier = ">=2.41.0.post3" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "fastmcp", specifier = ">=3.0" },
     { name = "jinja2", specifier = ">=3.1" },
-    { name = "mcp", specifier = ">=1.15.0" },
     { name = "nestedarchive", specifier = ">=0.2.4" },
     { name = "netaddr", specifier = ">=1.3.0" },
     { name = "prometheus-client", specifier = ">=0.22.1" },
@@ -236,6 +248,28 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
 name = "black"
 version = "25.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -260,6 +294,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/06/99/b2a4bd7dfaea7964974f947e1c76d6886d65fe5d24f687df2d85406b2609/black-25.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:97596189949a8aad13ad12fcbb4ae89330039b96ad6742e6f6b45e75ad5cfd83", size = 1452042, upload-time = "2025-12-08T01:46:13.188Z" },
     { url = "https://files.pythonhosted.org/packages/b2/7c/d9825de75ae5dd7795d007681b752275ea85a1c5d83269b4b9c754c2aaab/black-25.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:778285d9ea197f34704e3791ea9404cd6d07595745907dd2ce3da7a13627b29b", size = 1267446, upload-time = "2025-12-08T01:46:14.497Z" },
     { url = "https://files.pythonhosted.org/packages/68/11/21331aed19145a952ad28fca2756a1433ee9308079bd03bd898e903a2e53/black-25.12.0-py3-none-any.whl", hash = "sha256:48ceb36c16dbc84062740049eef990bb2ce07598272e673c17d1a7720c71c828", size = 206191, upload-time = "2025-12-08T01:40:50.963Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/c1/67cfb86aa21144796ff51068326d467fbef8ee42f8d08a3a8a926106cf0c/cachetools-7.1.3.tar.gz", hash = "sha256:135cfe944bc3c1e805505f65dae0bef375a2f96261171ab66c79ef77d0bda39d", size = 45780, upload-time = "2026-05-18T18:21:03.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/52/8ff5c1a3b2e821ced9b2998fba3ee29aa4525c0bf51e5ee55dd6f61a4ed5/cachetools-7.1.3-py3-none-any.whl", hash = "sha256:9876787e2346e20584d5cca236cb5d49d04e7193de91646f230725b2e1e8b804", size = 16763, upload-time = "2026-05-18T18:21:02.386Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -496,6 +556,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/70/f81df9a60825e716228c325a4842ff9a29e922b3197010981fd1abd88ad3/cyclopts-4.14.0.tar.gz", hash = "sha256:2cb3d619330fdc8ba0b5acece85618915078aeb56117d12b96e289a128783938", size = 177291, upload-time = "2026-05-18T12:53:40.912Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/fe/60f19e9b8779d46656e181626e94355a5120407c3c632c08fe6df78c434a/cyclopts-4.14.0-py3-none-any.whl", hash = "sha256:d01342bffb7fe0d5de4b1bf9ffd8d6722c879289f1accdc1a9acf4c23d243bc2", size = 214929, upload-time = "2026-05-18T12:53:39.598Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -514,6 +589,46 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.128.0"
 source = { registry = "https://pypi.org/simple" }
@@ -526,6 +641,66 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/a9/5c5a01b6abd5346bf60b97cfd29e4a86661940c27dd562bfcda07fd03519/fastmcp-3.3.1.tar.gz", hash = "sha256:979362ea557de42a5f40342563c7e4b236bcc8e7cd192715f50030695d1a71cd", size = 28681699, upload-time = "2026-05-15T15:50:39.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/11/6b1bdada6ccfe647d615ae63f9106f8136aec17971e9361546af01c7d38e/fastmcp-3.3.1-py3-none-any.whl", hash = "sha256:862440c5c4d281363a5995eee59d77f0f7cac1f18869038729cecf03b02fc522", size = 7903, upload-time = "2026-05-15T15:50:36.424Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/a0/627103e517e1d0d6f1eec633d5662d13e776f01b45ad188e4f5f7478b438/fastmcp_slim-3.3.1.tar.gz", hash = "sha256:0957835fc59452e143ab2f4b7836d2d2df9b2d9958408edc79ba8b56232b2a88", size = 567007, upload-time = "2026-05-15T15:50:10.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ee/97047f4cc2d7b1d46670d08d8ad01a96e7a748cc01c0b4b351ad8eddbc7a/fastmcp_slim-3.3.1-py3-none-any.whl", hash = "sha256:6cf1c2d77e3adb0d409d6825ed6b0b2a999062973e00b8eea03bd48bf9b4c043", size = 738644, upload-time = "2026-05-15T15:50:08.336Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+]
+server = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pyperclip" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 
 [[package]]
@@ -602,6 +777,15 @@ wheels = [
 ]
 
 [[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -657,6 +841,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -675,6 +871,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -684,6 +922,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/dc/5f768c2e391e9afabe5d18e3221346deb5fb6338565f1ccc9e7c6d7befdd/joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48", size = 231881, upload-time = "2026-05-06T04:58:13.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/3b/ad1cb22e75c963b1f07c8a2329bf47227ce7e4361df5eb2fb101b2ce33ef/joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e", size = 70464, upload-time = "2026-05-06T04:58:11.668Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
 ]
 
 [[package]]
@@ -702,6 +961,20 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema-path"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/86/cfee6dd25843bec0760f456599a4f7e7e40221a934b9229fda0662c859bc/jsonschema_path-0.4.6.tar.gz", hash = "sha256:c89eb635f4d497c9ac328eeff359c489755838806a7d033510a692e9576f5c4b", size = 15302, upload-time = "2026-04-27T18:57:08.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/43/3d3065c05a04bb550c143bfbb8e4fd7022cd327e1082bf257bac74923783/jsonschema_path-0.4.6-py3-none-any.whl", hash = "sha256:451354b5311fa955c3144e6e4e255388c751c0121c5570ec5bb9291dd42d08c9", size = 19565, upload-time = "2026-04-27T18:57:06.792Z" },
+]
+
+[[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -711,6 +984,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -752,6 +1042,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/61/33063e271949787a2f8dd33c5260357e3d512a114fc82ca7890b65a76e2d/librt-0.7.7-cp314-cp314t-win32.whl", hash = "sha256:5e419e0db70991b6ba037b70c1d5bbe92b20ddf82f31ad01d77a347ed9781398", size = 40277, upload-time = "2026-01-01T23:52:07.625Z" },
     { url = "https://files.pythonhosted.org/packages/06/21/1abd972349f83a696ea73159ac964e63e2d14086fdd9bc7ca878c25fced4/librt-0.7.7-cp314-cp314t-win_amd64.whl", hash = "sha256:d6b7d93657332c817b8d674ef6bf1ab7796b4f7ce05e420fd45bd258a72ac804", size = 46765, upload-time = "2026-01-01T23:52:08.647Z" },
     { url = "https://files.pythonhosted.org/packages/51/0e/b756c7708143a63fca65a51ca07990fa647db2cc8fcd65177b9e96680255/librt-0.7.7-cp314-cp314t-win_arm64.whl", hash = "sha256:142c2cd91794b79fd0ce113bd658993b7ede0fe93057668c2f98a45ca00b7e91", size = 39724, upload-time = "2026-01-01T23:52:09.745Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -838,6 +1140,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d5/2d/649d80a0ecf6a1f82632ca44bec21c0461a9d9fc8934d38cb5b319f2db5e/mcp-1.25.0.tar.gz", hash = "sha256:56310361ebf0364e2d438e5b45f7668cbb124e158bb358333cd06e49e83a6802", size = 605387, upload-time = "2025-12-19T10:19:56.985Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl", hash = "sha256:b37c38144a666add0862614cc79ec276e97d72aa8ca26d622818d4e278b9721a", size = 233076, upload-time = "2025-12-19T10:19:55.416Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
 ]
 
 [[package]]
@@ -988,12 +1308,46 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
 ]
 
 [[package]]
@@ -1111,6 +1465,31 @@ wheels = [
 ]
 
 [[package]]
+name = "py-key-value-aio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -1132,6 +1511,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -1255,6 +1639,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
 name = "pyright"
 version = "1.1.408"
 source = { registry = "https://pypi.org/simple" }
@@ -1344,11 +1737,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.21"
+version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/96/804520d0850c7db98e5ccb70282e29208723f0964e88ffd9d0da2f52ea09/python_multipart-0.0.21.tar.gz", hash = "sha256:7137ebd4d3bbf70ea1622998f902b97a29434a9e8dc40eb203bbcf7c2a2cba92", size = 37196, upload-time = "2025-12-17T09:24:22.446Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/76/03af049af4dcee5d27442f71b6924f01f3efb5d2bd34f23fcd563f2cc5f5/python_multipart-0.0.21-py3-none-any.whl", hash = "sha256:cf7a6713e01c87aa35387f4774e812c4361150938d20d232800f75ffcf266090", size = 24541, upload-time = "2025-12-17T09:24:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]
@@ -1371,6 +1764,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -1448,6 +1850,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9d/72/75d0b85443fbc8d9f38d08d2b1b67cc184ce35280e4a3813cda2f445f3a4/retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4", size = 6448, upload-time = "2016-05-11T13:58:51.541Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/0d/53aea75710af4528a25ed6837d71d117602b01946b307a3912cb3cfcbcba/retry-0.9.2-py2.py3-none-any.whl", hash = "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606", size = 7986, upload-time = "2016-05-11T13:58:39.925Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/56/3191bae66b08ccc637ea8120426068bcb361cc323c96404c310886937067/rich_rst-2.0.1.tar.gz", hash = "sha256:cbe236ed0901d1ec8427cc6a50bf0a34353ba28ad014dc24def68bfe7f3b9e68", size = 300570, upload-time = "2026-05-16T00:47:57.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/3d/55c17d3ebdf3cd81356002afe5bef9bb8af631db2819785b6eac845b925b/rich_rst-2.0.1-py3-none-any.whl", hash = "sha256:7ee15f345ce25fa02b582c272a6cdbaf0c21243e38061cea273cff659bf3ef61", size = 272922, upload-time = "2026-05-16T00:47:55.508Z" },
 ]
 
 [[package]]
@@ -1540,6 +1968,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/02/bb3ff8b6e6d02ce9e3740f4c17dfbbfb55f34c789c139e9cd91985f356c7/ruff-0.14.11-py3-none-win32.whl", hash = "sha256:337c5dd11f16ee52ae217757d9b82a26400be7efac883e9e852646f1557ed841", size = 12851094, upload-time = "2026-01-08T19:11:45.163Z" },
     { url = "https://files.pythonhosted.org/packages/58/f1/90ddc533918d3a2ad628bc3044cdfc094949e6d4b929220c3f0eb8a1c998/ruff-0.14.11-py3-none-win_amd64.whl", hash = "sha256:f981cea63d08456b2c070e64b79cb62f951aa1305282974d4d5216e6e0178ae6", size = 14001379, upload-time = "2026-01-08T19:11:52.591Z" },
     { url = "https://files.pythonhosted.org/packages/c4/1c/1dbe51782c0e1e9cfce1d1004752672d2d4629ea46945d19d731ad772b3b/ruff-0.14.11-py3-none-win_arm64.whl", hash = "sha256:649fb6c9edd7f751db276ef42df1f3df41c38d67d199570ae2a7bd6cbc3590f0", size = 12938644, upload-time = "2026-01-08T19:11:50.027Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]
@@ -1646,6 +2087,15 @@ wheels = [
 ]
 
 [[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1665,6 +2115,114 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]
@@ -1743,4 +2301,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## MCP Apps: Interactive UI dashboards with runtime client detection

This PR adds interactive UI dashboards to the Assisted Service MCP server using the MCP Apps extension, enabling visual cluster management in clients that support it (e.g., ChatGPT) while preserving full text-based functionality for clients that don't (e.g., Claude Code, Cursor, CLI agents).

### What's included

**Commit 1: Switch to FastMCP and add MCP Apps UI dashboards**

Migrates from `mcp` to `fastmcp>=3.0` and introduces three self-contained HTML dashboards rendered inline via the MCP Apps extension:

- **Cluster Inventory** (`ui://cluster-inventory`): Browse all clusters in a searchable table, drill into details, load events and logs, trigger cluster setup. Bound to the `list_clusters` tool.
- **Cluster Creator** (`ui://cluster-creator`): Form-based cluster creation with fields for name, version, domain, platform, architecture, and single-node toggle. Bound to the `open_cluster_creator` tool.
- **Cluster Setup** (`ui://cluster-setup`): Host registration dashboard showing discovery ISO download, discovered hosts with role assignment, VIP configuration, and install trigger with progress monitoring. Bound to `get_cluster_hosts`.

New tools added: `get_cluster_hosts`, `get_installation_progress`, `check_prerequisites`, `open_cluster_creator`.

Also adds auth header support (`OCM-Offline-Token`) as an alternative to the `OFFLINE_TOKEN` env var, and a comprehensive MCP Apps test suite covering resource registration, tool bindings, and new tool functionality.

**Commit 2: Improve dashboard UX**

Dark mode support via the MCP Apps theme API (`onhostcontextchanged`), simplified inventory table layout, improved detail view parsing, follow-up suggestion buttons for guided workflows across all dashboards, cross-widget navigation via `sendMessage`, and timing fixes for widget initialization.

**Commit 3: Fix widget tool integration and setup flow**

Server-side fixes for tools that back the widgets: `AppConfig` binding corrections (only widget-opening tools get `app=`), bytes-to-string conversion for event tool responses, setup widget improvements (cluster_id in host response, install status handling, SNO VIP skip logic), installation progress using `total_percentage`, and cleanup of debug instrumentation.

**Commit 4: Add contextual follow-up questions to tool responses**

Introduces `followups.py` — a module that appends structured "Suggested next steps" to tool responses for text-only clients. Questions are context-aware and vary by cluster status (pending/installing/installed/error), host discovery state, and installation progress. Format uses `[IMPORTANT]` directive blocks that instruct the LLM to present them as a numbered list. Widget HTML strips these blocks client-side via `stripFollowUps()` before parsing.

**Commit 5: Unify UI and text tools via runtime client detection**

Uses `ctx.client_supports_extension(UI_EXTENSION_ID)` from FastMCP to detect UI support at runtime. All tool functions now accept a `ui_supported: bool` parameter injected by the `_wrap_tool` wrapper via `Context`. Follow-up questions are only appended when `ui_supported=False`; UI clients get clean data for widget rendering.

The `_wrap_tool` method is updated to accept `ctx: Context` (auto-injected by FastMCP), resolve the access token and `ui_supported` flag, and forward both to the inner tool function. The exposed tool signature strips these internal params so only user-facing parameters appear in the MCP schema.

**Commit 6: Add open_cluster_creator tool for UI widget triggering**

Adds a dedicated zero-parameter `open_cluster_creator` tool registered with `app=_cre` to open the Creator widget. This solves the problem where `create_cluster` requires parameters (name, version, domain, single_node) that prevent the LLM from calling it immediately to open the widget form.

`create_cluster` reverts to a plain tool (no `app=` binding) — it's called internally by the Creator widget form after the user fills in the parameters. `stripFollowUps()` is restored in all widget HTML files since ChatGPT does not advertise UI extension support in its MCP capabilities.

### Architecture Example (Cluster Creator flow)

```mermaid
flowchart TD
    UserPrompt["User prompt"]
    LLM["LLM decides tool"]
    OpenCreator["open_cluster_creator - zero params, app=_cre"]
    Widget["Creator widget opens - HTML form"]
    FillForm["User fills form"]
    CreateCluster["Widget calls create_cluster with all params"]
    Created["Cluster created"]
    FollowUps["Follow-up buttons guide next steps"]

    UserPrompt --> LLM
    LLM --> OpenCreator
    OpenCreator --> Widget
    Widget --> FillForm
    FillForm --> CreateCluster
    CreateCluster --> Created
    Created --> FollowUps
```

For text-only clients, `open_cluster_creator` returns a text message listing required parameters, and the skill workflow handles the conversational param gathering.

### Testing

- 219 tests passing (35 new tests across 4 test files)
- `tests/mcp_apps/test_resources.py` — HTML loading, URI registration, MCP SDK presence
- `tests/mcp_apps/test_tool_bindings.py` — all 24 tools registered correctly
- `tests/mcp_apps/test_new_tools.py` — unit tests for new tools (both UI and text paths)
- `tests/tools/test_followups.py` — unit tests for all follow-up question generators


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive cluster creator dashboard for streamlined cluster provisioning
  * Added interactive cluster inventory dashboard with cluster listing, details, and event logs
  * Added interactive cluster setup dashboard for host configuration and installation management
  * Added cluster health prerequisites check to validate API connectivity and authentication
  * Added contextual follow-up suggestions for guided cluster management workflows
  * Enhanced MCP Apps SDK integration for improved UI experiences across all dashboards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->